### PR TITLE
Skeleton code for OS conditional build in rust

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-fn main() {
+#[cfg(target_os = "linux")]
+// Compiles assembly using Pearl on linux OS.
+fn build_linux() {
     // TODO - could ls directory and find all files
     let asm_to_build = [
         "add_mod_256-x86_64",
@@ -78,4 +80,25 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+}
+
+#[cfg(target_os = "windows")]
+fn build_windows() {
+    unimplemented!();
+}
+
+#[cfg(target_os = "macos")]
+fn build_macos() {
+    unimplemented!();
+}
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    build_linux();
+
+    #[cfg(target_os = "windows")]
+    build_windows();
+
+    #[cfg(target_os = "macos")]
+    build_macos();
 }


### PR DESCRIPTION
This is an example of how you can setup the build file such that it will compile and build on each operating system.

The documentation for the architectures can be found [here](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os).

Currently `unimplemented!()` will cause `macos` and `windows` to panic if they attempt to build.

There is conditional compilation in the `main()` such that each function will only be called if it is the correct operating system. Additionally the methods (e.g. `build_linux()`) use conditional compilation in case they have and functions which would not build on other OS.