### PR TITLE
API change

### DIFF
--- a/bindings/blst.h
+++ b/bindings/blst.h
@@ -258,15 +258,13 @@ typedef struct {} blst_pairing;
 #endif
 
 size_t blst_pairing_sizeof();
-void blst_pairing_init(blst_pairing *new_ctx);
+void blst_pairing_init(blst_pairing *new_ctx, bool hash_or_encode,
+                       const byte *DST DEFNULL, size_t DST_len DEFNULL);
 void blst_pairing_commit(blst_pairing *ctx);
 BLST_ERROR blst_pairing_aggregate_pk_in_g2(blst_pairing *ctx,
                                            const blst_p2_affine *PK,
                                            const blst_p1_affine *signature,
-                                           bool hash_or_encode,
                                            const byte *msg, size_t msg_len,
-                                           const byte *DST DEFNULL,
-                                           size_t DST_len DEFNULL,
                                            const byte *aug DEFNULL,
                                            size_t aug_len DEFNULL);
 BLST_ERROR blst_pairing_mul_n_aggregate_pk_in_g2(blst_pairing *ctx,
@@ -278,10 +276,7 @@ BLST_ERROR blst_pairing_mul_n_aggregate_pk_in_g2(blst_pairing *ctx,
 BLST_ERROR blst_pairing_aggregate_pk_in_g1(blst_pairing *ctx,
                                            const blst_p1_affine *PK,
                                            const blst_p2_affine *signature,
-                                           bool hash_or_encode,
                                            const byte *msg, size_t msg_len,
-                                           const byte *DST DEFNULL,
-                                           size_t DST_len DEFNULL,
                                            const byte *aug DEFNULL,
                                            size_t aug_len DEFNULL);
 BLST_ERROR blst_pairing_mul_n_aggregate_pk_in_g1(blst_pairing *ctx,

--- a/bindings/blst.h
+++ b/bindings/blst.h
@@ -270,9 +270,12 @@ BLST_ERROR blst_pairing_aggregate_pk_in_g2(blst_pairing *ctx,
 BLST_ERROR blst_pairing_mul_n_aggregate_pk_in_g2(blst_pairing *ctx,
                                                  const blst_p2_affine *PK,
                                                  const blst_p1_affine *sig,
-                                                 const blst_p1_affine *hash,
                                                  const limb_t *scalar,
-                                                 size_t nbits);
+                                                 size_t nbits,
+                                                 const byte *msg,
+                                                 size_t msg_len,
+                                                 const byte *aug DEFNULL,
+                                                 size_t aug_len DEFNULL);
 BLST_ERROR blst_pairing_aggregate_pk_in_g1(blst_pairing *ctx,
                                            const blst_p1_affine *PK,
                                            const blst_p2_affine *signature,
@@ -282,9 +285,12 @@ BLST_ERROR blst_pairing_aggregate_pk_in_g1(blst_pairing *ctx,
 BLST_ERROR blst_pairing_mul_n_aggregate_pk_in_g1(blst_pairing *ctx,
                                                  const blst_p1_affine *PK,
                                                  const blst_p2_affine *sig,
-                                                 const blst_p2_affine *hash,
                                                  const limb_t *scalar,
-                                                 size_t nbits);
+                                                 size_t nbits,
+                                                 const byte *msg,
+                                                 size_t msg_len,
+                                                 const byte *aug DEFNULL,
+                                                 size_t aug_len DEFNULL);
 BLST_ERROR blst_pairing_merge(blst_pairing *ctx, const blst_pairing *ctx1);
 bool blst_pairing_finalverify(const blst_pairing *ctx,
                               const blst_fp12 *gtsig DEFNULL);

--- a/bindings/go/blst.go
+++ b/bindings/go/blst.go
@@ -144,55 +144,51 @@ func PairingAggregatePkInG2(ctx Pairing, PK *P2Affine, sig *P1Affine,
 }
 
 func PairingMulNAggregatePkInG1(ctx Pairing, PK *P1Affine, sig *P2Affine,
-	rand *Scalar, randBits int, useHash bool, msg []byte,
-	optional ...[]byte) int {
-
-	var dst []byte
-	if len(optional) > 0 {
-		dst = optional[0]
-	}
-
+	rand *Scalar, randBits int, msg []byte,
+	optional ...[]byte) int { // aug
 	var aug []byte
-	if len(optional) > 1 {
-		aug = optional[1]
+	var uaug *C.byte
+	if len(optional) > 0 {
+		aug = optional[0]
+		if aug != nil {
+			uaug = (*C.byte)(&aug[0])
+		}
 	}
-
-	var hash *P2Affine
-	if useHash {
-		hash = HashToG2(msg, dst, aug).ToAffine()
-	} else {
-		hash = EncodeToG2(msg, dst, aug).ToAffine()
+	var umsg *C.byte
+	if msg != nil {
+		umsg = (*C.byte)(&msg[0])
 	}
 
 	r := C.blst_pairing_mul_n_aggregate_pk_in_g1((*C.blst_pairing)(&ctx[0]),
-		PK, sig, hash, &rand.l[0], C.size_t(randBits))
+		PK, sig,
+		&rand.l[0], C.size_t(randBits),
+		umsg, C.size_t(len(msg)),
+		uaug, C.size_t(len(aug)))
 
 	return int(r)
 }
 
 func PairingMulNAggregatePkInG2(ctx Pairing, PK *P2Affine, sig *P1Affine,
-	rand *Scalar, randBits int, useHash bool, msg []byte,
-	optional ...[]byte) int {
-
-	var dst []byte
-	if len(optional) > 0 {
-		dst = optional[0]
-	}
-
+	rand *Scalar, randBits int, msg []byte,
+	optional ...[]byte) int { // aug
 	var aug []byte
-	if len(optional) > 1 {
-		aug = optional[1]
+	var uaug *C.byte
+	if len(optional) > 0 {
+		aug = optional[0]
+		if aug != nil {
+			uaug = (*C.byte)(&aug[0])
+		}
 	}
-
-	var hash *P1Affine
-	if useHash {
-		hash = HashToG1(msg, dst, aug).ToAffine()
-	} else {
-		hash = EncodeToG1(msg, dst, aug).ToAffine()
+	var umsg *C.byte
+	if msg != nil {
+		umsg = (*C.byte)(&msg[0])
 	}
 
 	r := C.blst_pairing_mul_n_aggregate_pk_in_g2((*C.blst_pairing)(&ctx[0]),
-		PK, sig, hash, &rand.l[0], C.size_t(randBits))
+		PK, sig,
+		&rand.l[0], C.size_t(randBits),
+		umsg, C.size_t(len(msg)),
+		uaug, C.size_t(len(aug)))
 
 	return int(r)
 }
@@ -583,7 +579,7 @@ func multipleAggregateVerifyPkInG1(paramsFn mulAggGetterPkInG1, msgs []Message,
 					&tempPk, &tempRand)
 
 				if PairingMulNAggregatePkInG1(pairing, curPk, curSig,
-					curRand, randBits, useHash, msgs[work], dst, aug) !=
+					curRand, randBits, msgs[work], aug) !=
 					C.BLST_SUCCESS {
 					atomic.StoreInt32(&valid, 0)
 					break
@@ -1147,7 +1143,7 @@ func multipleAggregateVerifyPkInG2(paramsFn mulAggGetterPkInG2, msgs []Message,
 					&tempPk, &tempRand)
 
 				if PairingMulNAggregatePkInG2(pairing, curPk, curSig,
-					curRand, randBits, useHash, msgs[work], dst, aug) !=
+					curRand, randBits, msgs[work], aug) !=
 					C.BLST_SUCCESS {
 					atomic.StoreInt32(&valid, 0)
 					break

--- a/bindings/go/blst.tgo
+++ b/bindings/go/blst.tgo
@@ -135,55 +135,51 @@ func PairingAggregatePkInG2(ctx Pairing, PK *P2Affine, sig *P1Affine,
 }
 
 func PairingMulNAggregatePkInG1(ctx Pairing, PK *P1Affine, sig *P2Affine,
-    rand *Scalar, randBits int, useHash bool, msg []byte,
-    optional ...[]byte) int {
-
-    var dst []byte
-    if len(optional) > 0 {
-        dst = optional[0]
-    }
-
+                                rand *Scalar, randBits int, msg []byte,
+                                optional ...[]byte) int { // aug
     var aug []byte
-    if len(optional) > 1 {
-        aug = optional[1]
+    var uaug *C.byte
+    if len(optional) > 0 {
+        aug = optional[0]
+        if aug != nil {
+            uaug = (*C.byte)(&aug[0])
+        }
     }
-
-    var hash *P2Affine
-    if useHash {
-        hash = HashToG2(msg, dst, aug).ToAffine()
-    } else {
-        hash = EncodeToG2(msg, dst, aug).ToAffine()
+    var umsg *C.byte
+    if msg != nil {
+        umsg = (*C.byte)(&msg[0])
     }
 
     r := C.blst_pairing_mul_n_aggregate_pk_in_g1((*C.blst_pairing)(&ctx[0]),
-        PK, sig, hash, &rand.l[0], C.size_t(randBits))
+                                                 PK, sig,
+                                                 &rand.l[0], C.size_t(randBits),
+                                                 umsg, C.size_t(len(msg)),
+                                                 uaug, C.size_t(len(aug)))
 
     return int(r)
 }
 
 func PairingMulNAggregatePkInG2(ctx Pairing, PK *P2Affine, sig *P1Affine,
-    rand *Scalar, randBits int, useHash bool, msg []byte,
-    optional ...[]byte) int {
-
-    var dst []byte
-    if len(optional) > 0 {
-        dst = optional[0]
-    }
-
+                                rand *Scalar, randBits int, msg []byte,
+                                optional ...[]byte) int { // aug
     var aug []byte
-    if len(optional) > 1 {
-        aug = optional[1]
+    var uaug *C.byte
+    if len(optional) > 0 {
+        aug = optional[0]
+        if aug != nil {
+            uaug = (*C.byte)(&aug[0])
+        }
     }
-
-    var hash *P1Affine
-    if useHash {
-        hash = HashToG1(msg, dst, aug).ToAffine()
-    } else {
-        hash = EncodeToG1(msg, dst, aug).ToAffine()
+    var umsg *C.byte
+    if msg != nil {
+        umsg = (*C.byte)(&msg[0])
     }
 
     r := C.blst_pairing_mul_n_aggregate_pk_in_g2((*C.blst_pairing)(&ctx[0]),
-        PK, sig, hash, &rand.l[0], C.size_t(randBits))
+                                                 PK, sig,
+                                                 &rand.l[0], C.size_t(randBits),
+                                                 umsg, C.size_t(len(msg)),
+                                                 uaug, C.size_t(len(aug)))
 
     return int(r)
 }

--- a/bindings/go/blst.tgo
+++ b/bindings/go/blst.tgo
@@ -77,24 +77,24 @@ func KeyGen(ikm []byte, optional ...[]byte) *SecretKey {
 //
 // Pairing
 //
-func PairingCtx() Pairing {
+func PairingCtx(hash_or_encode bool, DST []byte) Pairing {
     ctx := make([]uint64, C.blst_pairing_sizeof()/8)
-    C.blst_pairing_init((*C.blst_pairing)(&ctx[0]))
+    var uDST *C.byte
+    if DST != nil {
+        uDST = (*C.byte)(&DST[0])
+    }
+    C.blst_pairing_init((*C.blst_pairing)(&ctx[0]), C.bool(hash_or_encode),
+                                                    uDST, C.size_t(len(DST)))
     return ctx
 }
 
 func PairingAggregatePkInG1(ctx Pairing, PK *P1Affine, sig *P2Affine,
-    hash_or_encode bool, msg []byte, optional ...[]byte) int {
-    var DST []byte
-    var uDST *C.byte
-    if len(optional) > 0 {
-        DST = optional[0]
-        uDST = (*C.byte)(&DST[0])
-    }
+                            msg []byte,
+                            optional ...[]byte) int { // aug
     var aug []byte
     var uaug *C.byte
-    if len(optional) > 1 {
-        aug = optional[1]
+    if len(optional) > 0 {
+        aug = optional[0]
         if aug != nil {
             uaug = (*C.byte)(&aug[0])
         }
@@ -104,37 +104,32 @@ func PairingAggregatePkInG1(ctx Pairing, PK *P1Affine, sig *P2Affine,
         umsg = (*C.byte)(&msg[0])
     }
 
-    r := C.blst_pairing_aggregate_pk_in_g1((*C.blst_pairing)(&ctx[0]),
-        PK, sig, C.bool(hash_or_encode),
-        umsg, C.size_t(len(msg)),
-        uDST, C.size_t(len(DST)),
-        uaug, C.size_t(len(aug)))
+    r := C.blst_pairing_aggregate_pk_in_g1((*C.blst_pairing)(&ctx[0]), PK, sig,
+                                           umsg, C.size_t(len(msg)),
+                                           uaug, C.size_t(len(aug)))
 
     return int(r)
 }
 
 func PairingAggregatePkInG2(ctx Pairing, PK *P2Affine, sig *P1Affine,
-    hash_or_encode bool, msg []byte, optional ...[]byte) int {
-    var DST []byte
-    var uDST *C.byte
-    if len(optional) > 0 {
-        DST = optional[0]
-        uDST = (*C.byte)(&DST[0])
-    }
+                            msg []byte,
+                            optional ...[]byte) int { // aug
     var aug []byte
     var uaug *C.byte
-    if len(optional) > 1 {
-        aug = optional[1]
+    if len(optional) > 0 {
+        aug = optional[0]
         if aug != nil {
             uaug = (*C.byte)(&aug[0])
         }
     }
+    var umsg *C.byte
+    if msg != nil {
+        umsg = (*C.byte)(&msg[0])
+    }
 
-    r := C.blst_pairing_aggregate_pk_in_g2((*C.blst_pairing)(&ctx[0]),
-        PK, sig, C.bool(hash_or_encode),
-        (*C.byte)(&msg[0]), C.size_t(len(msg)),
-        uDST, C.size_t(len(DST)),
-        uaug, C.size_t(len(aug)))
+    r := C.blst_pairing_aggregate_pk_in_g2((*C.blst_pairing)(&ctx[0]), PK, sig,
+                                           umsg, C.size_t(len(msg)),
+                                           uaug, C.size_t(len(aug)))
 
     return int(r)
 }

--- a/bindings/go/blst_minpk.tgo
+++ b/bindings/go/blst_minpk.tgo
@@ -369,7 +369,7 @@ func multipleAggregateVerifyPkInG1(paramsFn mulAggGetterPkInG1, msgs []Message,
                     &tempPk, &tempRand)
 
                 if PairingMulNAggregatePkInG1(pairing, curPk, curSig,
-                    curRand, randBits, useHash, msgs[work], dst, aug) !=
+                    curRand, randBits, msgs[work], aug) !=
                     C.BLST_SUCCESS {
                     atomic.StoreInt32(&valid, 0)
                     break

--- a/bindings/go/blst_minpk.tgo
+++ b/bindings/go/blst_minpk.tgo
@@ -206,7 +206,7 @@ func coreAggregateVerifyPkInG1(sigFn sigGetterP2, pkFn pkGetterP1,
     mutex.Lock()
     for tid := 0; tid < numThreads; tid++ {
         go func() {
-            pairing := PairingCtx()
+            pairing := PairingCtx(useHash, dst)
             var temp P1Affine
             for atomic.LoadInt32(&valid) > 0 {
                 // Get a work item
@@ -230,8 +230,7 @@ func coreAggregateVerifyPkInG1(sigFn sigGetterP2, pkFn pkGetterP1,
                 }
 
                 // Pairing and accumulate
-                PairingAggregatePkInG1(pairing, curPk, nil,
-                    useHash, msgs[work], dst, aug)
+                PairingAggregatePkInG1(pairing, curPk, nil, msgs[work], aug)
 
                 // application might have some async work to do
                 runtime.Gosched()
@@ -355,7 +354,7 @@ func multipleAggregateVerifyPkInG1(paramsFn mulAggGetterPkInG1, msgs []Message,
 
     for tid := 0; tid < numThreads; tid++ {
         go func() {
-            pairing := PairingCtx()
+            pairing := PairingCtx(useHash, dst)
             var tempRand Scalar
             var tempPk P1Affine
             var tempSig P2Affine

--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -793,9 +793,12 @@ extern "C" {
         ctx: *mut blst_pairing,
         PK: *const blst_p2_affine,
         sig: *const blst_p1_affine,
-        hash: *const blst_p1_affine,
         scalar: *const limb_t,
         nbits: usize,
+        msg: *const byte,
+        msg_len: usize,
+        aug: *const byte,
+        aug_len: usize,
     ) -> BLST_ERROR;
 }
 extern "C" {
@@ -814,9 +817,12 @@ extern "C" {
         ctx: *mut blst_pairing,
         PK: *const blst_p1_affine,
         sig: *const blst_p2_affine,
-        hash: *const blst_p2_affine,
         scalar: *const limb_t,
         nbits: usize,
+        msg: *const byte,
+        msg_len: usize,
+        aug: *const byte,
+        aug_len: usize,
     ) -> BLST_ERROR;
 }
 extern "C" {

--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -767,7 +767,12 @@ extern "C" {
     pub fn blst_pairing_sizeof() -> usize;
 }
 extern "C" {
-    pub fn blst_pairing_init(new_ctx: *mut blst_pairing);
+    pub fn blst_pairing_init(
+        new_ctx: *mut blst_pairing,
+        hash_or_encode: bool,
+        DST: *const byte,
+        DST_len: usize,
+    );
 }
 extern "C" {
     pub fn blst_pairing_commit(ctx: *mut blst_pairing);
@@ -777,11 +782,8 @@ extern "C" {
         ctx: *mut blst_pairing,
         PK: *const blst_p2_affine,
         signature: *const blst_p1_affine,
-        hash_or_encode: bool,
         msg: *const byte,
         msg_len: usize,
-        DST: *const byte,
-        DST_len: usize,
         aug: *const byte,
         aug_len: usize,
     ) -> BLST_ERROR;
@@ -801,11 +803,8 @@ extern "C" {
         ctx: *mut blst_pairing,
         PK: *const blst_p1_affine,
         signature: *const blst_p2_affine,
-        hash_or_encode: bool,
         msg: *const byte,
         msg_len: usize,
-        DST: *const byte,
-        DST_len: usize,
         aug: *const byte,
         aug_len: usize,
     ) -> BLST_ERROR;

--- a/src/aggregate.c
+++ b/src/aggregate.c
@@ -7,9 +7,9 @@
 /*
  * Usage pattern on single-processor system is
  *
- * blst_pairing_init(ctx);
- * blst_pairing_aggregate_pk_in_g1(ctx, PK1, aggregated_signature, message1);
- * blst_pairing_aggregate_pk_in_g1(ctx, PK2, NULL, message2);
+ * blst_pairing_init(ctx, hash_or_encode, DST);
+ * blst_pairing_aggregate_pk_in_g1(ctx, PK[0], aggregated_signature, msg[0]);
+ * blst_pairing_aggregate_pk_in_g1(ctx, PK[1], NULL, msg[1]);
  * ...
  * blst_pairing_commit(ctx);
  * blst_pairing_finalverify(ctx, NULL);
@@ -17,20 +17,23 @@
  ***********************************************************************
  * Usage pattern on multi-processor system is
  *
- *   blst_pairing_init(pk0);
- *   blst_pairing_init(pk1);
+ *   blst_pairing_init(pk[0]);
+ *   blst_pairing_init(pk[1]);
  *   ...
- * start threads each processing a slice of PKs and messages:
- *     blst_pairing_aggregate_pk_in_g1(pkx, PK[], NULL, message[]);
+ * start threads each processing an N/nthreads slice of PKs and messages:
+ *     blst_pairing_aggregate_pk_in_g1(pk[i], PK[i*n+0], NULL, msg[i*n+0]);
+ *     blst_pairing_aggregate_pk_in_g1(pk[i], PK[i*n+1], NULL, msg[i*n+1]);
+ *     ...
  *     blst_pairing_commit(pkx);
  *   ...
+ * meanwhile in main thread
  *   blst_fp12 gtsig;
  *   blst_aggregated_in_g2(&gtsig, aggregated_signature);
  * join threads and merge their contexts:
- *   blst_pairing_merge(pk0, pk1);
- *   blst_pairing_merge(pk0, pk2);
+ *   blst_pairing_merge(pk[0], pk[1]);
+ *   blst_pairing_merge(pk[0], pk[2]);
  *   ...
- *   blst_pairing_finalverify(pk0, gtsig);
+ *   blst_pairing_finalverify(pk[0], gtsig);
  */
 
 #ifndef N_MAX
@@ -39,8 +42,10 @@
 
 typedef union { POINTonE1 e1; POINTonE2 e2; } AggregatedSignature;
 typedef struct {
-    unsigned int min_sig_or_pk;
+    unsigned int ctrl;
     unsigned int nelems;
+    const void *DST;
+    size_t DST_len;
     vec384fp12 GT;
     AggregatedSignature AggrSign;
     POINTonE2_affine Q[N_MAX];
@@ -48,13 +53,21 @@ typedef struct {
 } PAIRING;
 
 enum { AGGR_UNDEFINED = 0, AGGR_MIN_SIG, AGGR_MIN_PK,
-       AGGR_SIGN_SET = 0x10, AGGR_GT_SET = 0x20 };
+       AGGR_SIGN_SET = 0x10, AGGR_GT_SET = 0x20,
+       AGGR_HASH_OR_ENCODE = 0x40 };
+#define MIN_SIG_OR_PK (AGGR_MIN_SIG | AGGR_MIN_PK)
 
 size_t blst_pairing_sizeof(void)
 {   return (sizeof(PAIRING) + 7) & ~(size_t)7;   }
 
-void blst_pairing_init(PAIRING *ctx)
-{   ctx->min_sig_or_pk = AGGR_UNDEFINED; ctx->nelems = 0;   }
+void blst_pairing_init(PAIRING *ctx, int hash_or_encode,
+                       const void *DST, size_t DST_len)
+{
+    ctx->ctrl = AGGR_UNDEFINED | (hash_or_encode ? AGGR_HASH_OR_ENCODE : 0);
+    ctx->nelems = 0;
+    ctx->DST = DST;
+    ctx->DST_len = DST_len;
+}
 
 #define FROM_AFFINE(out,in) do { \
     vec_copy((out)->X, in->X, 2*sizeof(in->X)), \
@@ -64,25 +77,23 @@ void blst_pairing_init(PAIRING *ctx)
 static BLST_ERROR PAIRING_Aggregate_PK_in_G2(PAIRING *ctx,
                                              const POINTonE2_affine *PK,
                                              const POINTonE1_affine *sig,
-                                             int hash_or_encode,
                                              const void *msg, size_t msg_len,
-                                             const void *DST, size_t DST_len,
                                              const void *aug, size_t aug_len)
 {
-    if (ctx->min_sig_or_pk & AGGR_MIN_PK)
+    if (ctx->ctrl & AGGR_MIN_PK)
         return BLST_AGGR_TYPE_MISMATCH;
 
-    ctx->min_sig_or_pk |= AGGR_MIN_SIG;
+    ctx->ctrl |= AGGR_MIN_SIG;
 
     if (sig != NULL) {
         if (!POINTonE1_in_G1((const POINTonE1 *)sig))
             return BLST_POINT_NOT_IN_GROUP;
 
-        if (ctx->min_sig_or_pk & AGGR_SIGN_SET) {
+        if (ctx->ctrl & AGGR_SIGN_SET) {
             POINTonE1_dadd_affine(&ctx->AggrSign.e1, &ctx->AggrSign.e1,
                                                      (const POINTonE1 *)sig);
         } else {
-            ctx->min_sig_or_pk |= AGGR_SIGN_SET;
+            ctx->ctrl |= AGGR_SIGN_SET;
             FROM_AFFINE(&ctx->AggrSign.e1, sig);
         }
     }
@@ -91,10 +102,10 @@ static BLST_ERROR PAIRING_Aggregate_PK_in_G2(PAIRING *ctx,
         unsigned int n;
         POINTonE1 H[1];
 
-        if (hash_or_encode)
-            Hash_to_G1(H, msg, msg_len, DST, DST_len, aug, aug_len);
+        if (ctx->ctrl & AGGR_HASH_OR_ENCODE)
+            Hash_to_G1(H, msg, msg_len, ctx->DST, ctx->DST_len, aug, aug_len);
         else
-            Encode_to_G1(H, msg, msg_len, DST, DST_len, aug, aug_len);
+            Encode_to_G1(H, msg, msg_len, ctx->DST, ctx->DST_len, aug, aug_len);
 
         POINTonE1_from_Jacobian(H, H);
 
@@ -102,13 +113,13 @@ static BLST_ERROR PAIRING_Aggregate_PK_in_G2(PAIRING *ctx,
         vec_copy(ctx->Q + n, PK, sizeof(POINTonE2_affine));
         vec_copy(ctx->P + n, H, sizeof(POINTonE1_affine));
         if (++n == N_MAX) {
-            if (ctx->min_sig_or_pk & AGGR_GT_SET) {
+            if (ctx->ctrl & AGGR_GT_SET) {
                 vec384fp12 GT;
                 miller_loop_n(GT, ctx->Q, ctx->P, n);
                 mul_fp12(ctx->GT, ctx->GT, GT);
             } else {
                 miller_loop_n(ctx->GT, ctx->Q, ctx->P, n);
-                ctx->min_sig_or_pk |= AGGR_GT_SET;
+                ctx->ctrl |= AGGR_GT_SET;
             }
             n = 0;
         }
@@ -121,36 +132,32 @@ static BLST_ERROR PAIRING_Aggregate_PK_in_G2(PAIRING *ctx,
 BLST_ERROR blst_pairing_aggregate_pk_in_g2(PAIRING *ctx,
                                            const POINTonE2_affine *PK,
                                            const POINTonE1_affine *signature,
-                                           int hash_or_encode,
                                            const void *msg, size_t msg_len,
-                                           const void *DST, size_t DST_len,
                                            const void *aug, size_t aug_len)
-{   return PAIRING_Aggregate_PK_in_G2(ctx, PK, signature, hash_or_encode,
-                                      msg, msg_len, DST, DST_len, aug, aug_len);
+{   return PAIRING_Aggregate_PK_in_G2(ctx, PK, signature, msg, msg_len,
+                                                          aug, aug_len);
 }
 
 static BLST_ERROR PAIRING_Aggregate_PK_in_G1(PAIRING *ctx,
                                              const POINTonE1_affine *PK,
                                              const POINTonE2_affine *sig,
-                                             int hash_or_encode,
                                              const void *msg, size_t msg_len,
-                                             const void *DST, size_t DST_len,
                                              const void *aug, size_t aug_len)
 {
-    if (ctx->min_sig_or_pk & AGGR_MIN_SIG)
+    if (ctx->ctrl & AGGR_MIN_SIG)
         return BLST_AGGR_TYPE_MISMATCH;
 
-    ctx->min_sig_or_pk |= AGGR_MIN_PK;
+    ctx->ctrl |= AGGR_MIN_PK;
 
     if (sig != NULL) {
         if (!POINTonE2_in_G2((const POINTonE2 *)sig))
             return BLST_POINT_NOT_IN_GROUP;
 
-        if (ctx->min_sig_or_pk & AGGR_SIGN_SET) {
+        if (ctx->ctrl & AGGR_SIGN_SET) {
             POINTonE2_dadd_affine(&ctx->AggrSign.e2, &ctx->AggrSign.e2,
                                                      (const POINTonE2 *)sig);
         } else {
-            ctx->min_sig_or_pk |= AGGR_SIGN_SET;
+            ctx->ctrl |= AGGR_SIGN_SET;
             FROM_AFFINE(&ctx->AggrSign.e2, sig);
         }
     }
@@ -159,10 +166,10 @@ static BLST_ERROR PAIRING_Aggregate_PK_in_G1(PAIRING *ctx,
         unsigned int n;
         POINTonE2 H[1];
 
-        if (hash_or_encode)
-            Hash_to_G2(H, msg, msg_len, DST, DST_len, aug, aug_len);
+        if (ctx->ctrl & AGGR_HASH_OR_ENCODE)
+            Hash_to_G2(H, msg, msg_len, ctx->DST, ctx->DST_len, aug, aug_len);
         else
-            Encode_to_G2(H, msg, msg_len, DST, DST_len, aug, aug_len);
+            Encode_to_G2(H, msg, msg_len, ctx->DST, ctx->DST_len, aug, aug_len);
 
         POINTonE2_from_Jacobian(H, H);
 
@@ -170,13 +177,13 @@ static BLST_ERROR PAIRING_Aggregate_PK_in_G1(PAIRING *ctx,
         vec_copy(ctx->Q + n, H, sizeof(POINTonE2_affine));
         vec_copy(ctx->P + n, PK, sizeof(POINTonE1_affine));
         if (++n == N_MAX) {
-            if (ctx->min_sig_or_pk & AGGR_GT_SET) {
+            if (ctx->ctrl & AGGR_GT_SET) {
                 vec384fp12 GT;
                 miller_loop_n(GT, ctx->Q, ctx->P, n);
                 mul_fp12(ctx->GT, ctx->GT, GT);
             } else {
                 miller_loop_n(ctx->GT, ctx->Q, ctx->P, n);
-                ctx->min_sig_or_pk |= AGGR_GT_SET;
+                ctx->ctrl |= AGGR_GT_SET;
             }
             n = 0;
         }
@@ -189,12 +196,10 @@ static BLST_ERROR PAIRING_Aggregate_PK_in_G1(PAIRING *ctx,
 BLST_ERROR blst_pairing_aggregate_pk_in_g1(PAIRING *ctx,
                                            const POINTonE1_affine *PK,
                                            const POINTonE2_affine *signature,
-                                           int hash_or_encode,
                                            const void *msg, size_t msg_len,
-                                           const void *DST, size_t DST_len,
                                            const void *aug, size_t aug_len)
-{   return PAIRING_Aggregate_PK_in_G1(ctx, PK, signature, hash_or_encode,
-                                      msg, msg_len, DST, DST_len, aug, aug_len);
+{   return PAIRING_Aggregate_PK_in_G1(ctx, PK, signature, msg, msg_len,
+                                                          aug, aug_len);
 }
 
 static BLST_ERROR PAIRING_Mul_n_Aggregate_PK_in_G2(PAIRING *ctx,
@@ -204,16 +209,16 @@ static BLST_ERROR PAIRING_Mul_n_Aggregate_PK_in_G2(PAIRING *ctx,
                                                    const limb_t *scalar,
                                                    size_t nbits)
 {
-    if (ctx->min_sig_or_pk & AGGR_MIN_PK)
+    if (ctx->ctrl & AGGR_MIN_PK)
         return BLST_AGGR_TYPE_MISMATCH;
 
-    ctx->min_sig_or_pk |= AGGR_MIN_SIG;
+    ctx->ctrl |= AGGR_MIN_SIG;
 
     if (sig != NULL) {
         if (!POINTonE1_in_G1((const POINTonE1 *)sig))
             return BLST_POINT_NOT_IN_GROUP;
 
-        if (ctx->min_sig_or_pk & AGGR_SIGN_SET) {
+        if (ctx->ctrl & AGGR_SIGN_SET) {
             POINTonE1 P[1];
 
             FROM_AFFINE(P, sig);
@@ -222,7 +227,7 @@ static BLST_ERROR PAIRING_Mul_n_Aggregate_PK_in_G2(PAIRING *ctx,
         } else {
             POINTonE1 *P = &ctx->AggrSign.e1;
 
-            ctx->min_sig_or_pk |= AGGR_SIGN_SET;
+            ctx->ctrl |= AGGR_SIGN_SET;
             FROM_AFFINE(P, sig);
             POINTonE1_mult_w5(P, P, scalar, nbits);
         }
@@ -240,13 +245,13 @@ static BLST_ERROR PAIRING_Mul_n_Aggregate_PK_in_G2(PAIRING *ctx,
         vec_copy(ctx->Q + n, PK, sizeof(POINTonE2_affine));
         vec_copy(ctx->P + n, H, sizeof(POINTonE1_affine));
         if (++n == N_MAX) {
-            if (ctx->min_sig_or_pk & AGGR_GT_SET) {
+            if (ctx->ctrl & AGGR_GT_SET) {
                 vec384fp12 GT;
                 miller_loop_n(GT, ctx->Q, ctx->P, n);
                 mul_fp12(ctx->GT, ctx->GT, GT);
             } else {
                 miller_loop_n(ctx->GT, ctx->Q, ctx->P, n);
-                ctx->min_sig_or_pk |= AGGR_GT_SET;
+                ctx->ctrl |= AGGR_GT_SET;
             }
             n = 0;
         }
@@ -272,16 +277,16 @@ static BLST_ERROR PAIRING_Mul_n_Aggregate_PK_in_G1(PAIRING *ctx,
                                                    const limb_t *scalar,
                                                    size_t nbits)
 {
-    if (ctx->min_sig_or_pk & AGGR_MIN_SIG)
+    if (ctx->ctrl & AGGR_MIN_SIG)
         return BLST_AGGR_TYPE_MISMATCH;
 
-    ctx->min_sig_or_pk |= AGGR_MIN_PK;
+    ctx->ctrl |= AGGR_MIN_PK;
 
     if (sig != NULL) {
         if (!POINTonE2_in_G2((const POINTonE2 *)sig))
             return BLST_POINT_NOT_IN_GROUP;
 
-        if (ctx->min_sig_or_pk & AGGR_SIGN_SET) {
+        if (ctx->ctrl & AGGR_SIGN_SET) {
             POINTonE2 P[1];
 
             FROM_AFFINE(P, sig);
@@ -290,7 +295,7 @@ static BLST_ERROR PAIRING_Mul_n_Aggregate_PK_in_G1(PAIRING *ctx,
         } else {
             POINTonE2 *P = &ctx->AggrSign.e2;
 
-            ctx->min_sig_or_pk |= AGGR_SIGN_SET;
+            ctx->ctrl |= AGGR_SIGN_SET;
             FROM_AFFINE(P, sig);
             POINTonE2_mult_w5(P, P, scalar, nbits);
         }
@@ -308,13 +313,13 @@ static BLST_ERROR PAIRING_Mul_n_Aggregate_PK_in_G1(PAIRING *ctx,
         vec_copy(ctx->Q + n, hash, sizeof(POINTonE2_affine));
         vec_copy(ctx->P + n, pk, sizeof(POINTonE1_affine));
         if (++n == N_MAX) {
-            if (ctx->min_sig_or_pk & AGGR_GT_SET) {
+            if (ctx->ctrl & AGGR_GT_SET) {
                 vec384fp12 GT;
                 miller_loop_n(GT, ctx->Q, ctx->P, n);
                 mul_fp12(ctx->GT, ctx->GT, GT);
             } else {
                 miller_loop_n(ctx->GT, ctx->Q, ctx->P, n);
-                ctx->min_sig_or_pk |= AGGR_GT_SET;
+                ctx->ctrl |= AGGR_GT_SET;
             }
             n = 0;
         }
@@ -338,13 +343,13 @@ static void PAIRING_Commit(PAIRING *ctx)
     unsigned int n;
 
     if ((n = ctx->nelems) != 0) {
-        if (ctx->min_sig_or_pk & AGGR_GT_SET) {
+        if (ctx->ctrl & AGGR_GT_SET) {
             vec384fp12 GT;
             miller_loop_n(GT, ctx->Q, ctx->P, n);
             mul_fp12(ctx->GT, ctx->GT, GT);
         } else {
             miller_loop_n(ctx->GT, ctx->Q, ctx->P, n);
-            ctx->min_sig_or_pk |= AGGR_GT_SET;
+            ctx->ctrl |= AGGR_GT_SET;
         }
         ctx->nelems = 0;
     }
@@ -355,31 +360,31 @@ void blst_pairing_commit(PAIRING *ctx)
 
 BLST_ERROR blst_pairing_merge(PAIRING *ctx, const PAIRING *ctx1)
 {
-    if (ctx->min_sig_or_pk != AGGR_UNDEFINED
-        && (ctx->min_sig_or_pk & ctx1->min_sig_or_pk & 3) == 0)
+    if ((ctx->ctrl & MIN_SIG_OR_PK) != AGGR_UNDEFINED
+        && (ctx->ctrl & ctx1->ctrl & MIN_SIG_OR_PK) == 0)
         return BLST_AGGR_TYPE_MISMATCH;
 
     /* context producers are expected to have called blst_pairing_commit */
     if (ctx->nelems || ctx1->nelems)
         return BLST_AGGR_TYPE_MISMATCH;
 
-    switch (ctx->min_sig_or_pk & 3) {
+    switch (ctx->ctrl & MIN_SIG_OR_PK) {
         case AGGR_MIN_SIG:
-            if (ctx->min_sig_or_pk & ctx1->min_sig_or_pk & AGGR_SIGN_SET) {
+            if (ctx->ctrl & ctx1->ctrl & AGGR_SIGN_SET) {
                 POINTonE1_dadd(&ctx->AggrSign.e1, &ctx->AggrSign.e1,
                                                   &ctx1->AggrSign.e1, NULL);
-            } else if (ctx1->min_sig_or_pk & AGGR_SIGN_SET) {
-                ctx->min_sig_or_pk |= AGGR_SIGN_SET;
+            } else if (ctx1->ctrl & AGGR_SIGN_SET) {
+                ctx->ctrl |= AGGR_SIGN_SET;
                 vec_copy(&ctx->AggrSign.e1, &ctx1->AggrSign.e1,
                          sizeof(ctx->AggrSign.e1));
             }
             break;
         case AGGR_MIN_PK:
-            if (ctx->min_sig_or_pk & ctx1->min_sig_or_pk & AGGR_SIGN_SET) {
+            if (ctx->ctrl & ctx1->ctrl & AGGR_SIGN_SET) {
                 POINTonE2_dadd(&ctx->AggrSign.e2, &ctx->AggrSign.e2,
                                                   &ctx1->AggrSign.e2, NULL);
-            } else if (ctx1->min_sig_or_pk & AGGR_SIGN_SET) {
-                ctx->min_sig_or_pk |= AGGR_SIGN_SET;
+            } else if (ctx1->ctrl & AGGR_SIGN_SET) {
+                ctx->ctrl |= AGGR_SIGN_SET;
                 vec_copy(&ctx->AggrSign.e2, &ctx1->AggrSign.e2,
                          sizeof(ctx->AggrSign.e2));
             }
@@ -391,10 +396,10 @@ BLST_ERROR blst_pairing_merge(PAIRING *ctx, const PAIRING *ctx1)
             return BLST_AGGR_TYPE_MISMATCH;
     }
 
-    if (ctx->min_sig_or_pk & ctx1->min_sig_or_pk & AGGR_GT_SET) {
+    if (ctx->ctrl & ctx1->ctrl & AGGR_GT_SET) {
         mul_fp12(ctx->GT, ctx->GT, ctx1->GT);
-    } else if (ctx1->min_sig_or_pk & AGGR_GT_SET) {
-        ctx->min_sig_or_pk |= AGGR_GT_SET;
+    } else if (ctx1->ctrl & AGGR_GT_SET) {
+        ctx->ctrl |= AGGR_GT_SET;
         vec_copy(ctx->GT, ctx1->GT, sizeof(ctx->GT));
     }
 
@@ -405,15 +410,15 @@ static limb_t PAIRING_FinalVerify(const PAIRING *ctx, const vec384fp12 GTsig)
 {
     vec384fp12 GT;
 
-    if (!(ctx->min_sig_or_pk & AGGR_GT_SET))
+    if (!(ctx->ctrl & AGGR_GT_SET))
         return 0;
 
     if (GTsig != NULL) {
         vec_copy(GT, GTsig, sizeof(GT));
-    } else if (ctx->min_sig_or_pk & AGGR_SIGN_SET) {
+    } else if (ctx->ctrl & AGGR_SIGN_SET) {
         AggregatedSignature AggrSign;
 
-        switch (ctx->min_sig_or_pk & 3) {
+        switch (ctx->ctrl & MIN_SIG_OR_PK) {
             case AGGR_MIN_SIG:
                 POINTonE1_from_Jacobian(&AggrSign.e1, &ctx->AggrSign.e1);
                 miller_loop_n(GT, (const POINTonE2_affine *)&BLS12_381_G2,
@@ -534,11 +539,13 @@ BLST_ERROR blst_core_verify_pk_in_g1(const POINTonE1_affine *pk,
     PAIRING ctx;
     BLST_ERROR ret;
 
-    ctx.min_sig_or_pk = AGGR_UNDEFINED;
+    ctx.ctrl = AGGR_UNDEFINED | (hash_or_encode ? AGGR_HASH_OR_ENCODE : 0);
     ctx.nelems = 0;
+    ctx.DST = DST;
+    ctx.DST_len = DST_len;
 
-    ret = PAIRING_Aggregate_PK_in_G1(&ctx, pk, signature, hash_or_encode,
-                                     msg, msg_len, DST, DST_len, aug, aug_len);
+    ret = PAIRING_Aggregate_PK_in_G1(&ctx, pk, signature, msg, msg_len,
+                                                          aug, aug_len);
     if (ret != BLST_SUCCESS)
         return ret;
 
@@ -557,11 +564,13 @@ BLST_ERROR blst_core_verify_pk_in_g2(const POINTonE2_affine *pk,
     PAIRING ctx;
     BLST_ERROR ret;
 
-    ctx.min_sig_or_pk = AGGR_UNDEFINED;
+    ctx.ctrl = AGGR_UNDEFINED | (hash_or_encode ? AGGR_HASH_OR_ENCODE : 0);
     ctx.nelems = 0;
+    ctx.DST = DST;
+    ctx.DST_len = DST_len;
 
-    ret = PAIRING_Aggregate_PK_in_G2(&ctx, pk, signature, hash_or_encode,
-                                     msg, msg_len, DST, DST_len, aug, aug_len);
+    ret = PAIRING_Aggregate_PK_in_G2(&ctx, pk, signature, msg, msg_len,
+                                                          aug, aug_len);
     if (ret != BLST_SUCCESS)
         return ret;
 


### PR DESCRIPTION
It doesn't affect highest-level interfaces in Go and Rust bindings. Most important is move of hash_or_encode into mul_n_aggregage, and underlying rationale is to facilitate [future] vectorization.