### PR TITLE
Tidy up `from_bytes()` and Pointers

### DIFF
--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -69,7 +69,7 @@ fn bindgen_test_layout_blst_fr() {
     );
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct blst_fp {
     pub l: [limb_t; 6usize],
 }
@@ -97,7 +97,7 @@ fn bindgen_test_layout_blst_fp() {
     );
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct blst_fp2 {
     pub fp: [blst_fp; 2usize],
 }
@@ -125,7 +125,7 @@ fn bindgen_test_layout_blst_fp2() {
     );
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct blst_fp6 {
     pub fp2: [blst_fp2; 3usize],
 }
@@ -153,7 +153,7 @@ fn bindgen_test_layout_blst_fp6() {
     );
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct blst_fp12 {
     pub fp6: [blst_fp6; 2usize],
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -361,7 +361,7 @@ macro_rules! sig_variant_impl {
             }
 
             pub fn from_bytes(sk_in: &[u8]) -> Result<Self, BLST_ERROR> {
-                Ok(SecretKey::deserialize(sk_in)?) // TODO - is this correct?
+                SecretKey::deserialize(sk_in)
             }
         }
 


### PR DESCRIPTION
# What has been changed

The return value does not need to be unwrapped then re-wrapped since both functions have the same return value `Result<Self, BLST_ERROR>`.

A `*const` for a element of a struct can be obtained by `&struct.element` this saves the need for deferencing then accessing the pointer's struct element then referencing. 

Add `Default` trait to avoid `uninit().assume_init()` which is not recommended. It is expected that calls to `default()` should be optimised out during compilation as the values are not used. There is the potential to be used in many other places, would be good to run the benches before and after using default in all locations to test the efficiency of the compiler on this issue.