### PR TITLE
replace march flag with adx for arch agnostic builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ done
 
 arch=`uname -m`
 if (${CC} ${CFLAGS} -dM -E -x c /dev/null) 2>/dev/null | grep -q $arch; then
-    CFLAGS="${CFLAGS} -march=native"
+    CFLAGS="${CFLAGS} -D__ADX__"
     [ "$arch" = "x86_64" ] && CFLAGS="${CFLAGS} -mno-avx"
 fi
 


### PR DESCRIPTION
the march=native flag was causing panics when built on one architecture
and ran on another.
for example compiling blst on a system with AMD architecture and running
binary on an Intel system would result in a panic.
blst would be built with the sha-ni extensions on that Ryzen platform
that then wouldn't have been available on that Intel processor.
using the ADX flag will work on Intel/AMD processor from the last ~ 5 years