### PR TITLE
Improve Rust bindings and build tools

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -20,6 +20,14 @@ include = [
     "blst/bindings/blst_aux.h",
 ]
 
+[features]
+# By default, compile with ADX and SHA extensions enabled if the host supports them.
+default = []
+# Compile in portable mode, without ADX or SHA extensions.
+portable = []
+# Enable ADX even if the host CPU doesn't support it.
+force-adx = []
+
 [build-dependencies]
 cc = "1.0"
 glob = "0.3"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -484,6 +484,12 @@ macro_rules! sig_variant_impl {
             }
         }
 
+        // Trait for equality comparisons which are equivalence relations.
+        //
+        // This means, that in addition to a == b and a != b being strict inverses, the equality
+        // must be reflexive, symmetric and transitive.
+        impl Eq for PublicKey {}
+
         impl PartialEq for PublicKey {
             fn eq(&self, other: &Self) -> bool {
                 unsafe { $pk_eq(&self.point, &other.point) }
@@ -883,6 +889,12 @@ macro_rules! sig_variant_impl {
                 self.compress()
             }
         }
+
+        // Trait for equality comparisons which are equivalence relations.
+        //
+        // This means, that in addition to a == b and a != b being strict inverses, the equality
+        // must be reflexive, symmetric and transitive.
+        impl Eq for Signature {}
 
         impl PartialEq for Signature {
             fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
This PR incorporates two changes that have been lurking in `sigp`'s fork of BLST that should really live upstream:

* Implement the `Eq` trait for `PublicKey` and `Signature` (resolves https://github.com/supranational/blst/issues/12)
* Tweak `build.rs` so it supports the two compilation configurations we want via Cargo features:
  + `feature = portable`: for pre-2013 CPUs, disables ADX, turns on `__BLST_PORTABLE__` in the C build
  + `feature = force-adx`: for post-2013 CPUs, enables ADX even if it isn't detected on the host
  + `feature = default` (no features provided): for all CPUs and source builds, enables ADX if it is present on the host

We're likely to ship two binaries, one `portable` and one `force-adx`. The reason for making `force-adx` its own feature is so we can know when a binary is intended for a modern CPU, and raise an appropriate runtime error if ADX support isn't detected at runtime (instead of just `SIGILL`).

I also replaced `is_adx` by a call to the [`is_x86_feature_detected!`](https://doc.rust-lang.org/stable/std/macro.is_x86_feature_detected.html) macro from the standard library, which is equivalent as far as I understand.