### PR TITLE
Expose subgroup check for signatures

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -888,6 +888,12 @@ macro_rules! sig_variant_impl {
             pub fn to_bytes(&self) -> [u8; $sig_comp_size] {
                 self.compress()
             }
+
+            pub fn subgroup_check(&self) -> bool {
+                unsafe {
+                    $sig_in_group(&self.point)
+                }
+            }
         }
 
         // Trait for equality comparisons which are equivalence relations.

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -988,6 +988,14 @@ macro_rules! sig_variant_impl {
                     );
                 }
             }
+
+            pub fn subgroup_check(&self) -> bool {
+                let mut sig = <$sig_aff>::default();
+                unsafe {
+                    $sig_to_aff(&mut sig, &self.point);
+                    $sig_in_group(&sig)
+                }
+            }
         }
 
         #[cfg(test)]


### PR DESCRIPTION
# What has been changed

Adds the binding to rust which allows the subgroup check to be made for signatures.