### PR TITLE
Radix384 change

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -10,7 +10,7 @@
 extern const vec384 BLS12_381_P;
 extern const limb_t BLS12_381_p0;
 static const limb_t p0 = (limb_t)0x89f3fffcfffcfffd;  /* -1/P */
-typedef union { vec384x p2; vec384 p; vec384 p12[12]; } radix384;
+typedef union { vec384 p12[12]; vec384x p2; vec384 p; } radix384;
 extern const radix384 BLS12_381_Rx; /* (1<<384)%P, "radix", one-in-Montgomery */
 extern const vec384 BLS12_381_RR;   /* (1<<768)%P, "radix"^2, to-Montgomery   */
 


### PR DESCRIPTION
I think that it is possible that some compilers may not initialize `BLS12_381_Rx` correctly. For example, I get the following from clang on my setup:
```
@BLS12_381_Rx = constant { [2 x [6 x i64]], [480 x i8] } { [2 x [6 x i64]] [[6 x i64] [i64 8505329371266088957, i64 -1444529529945325566, i64 6865905132761471162, i64 8632934651105793861, i64 6631298214892334189, i64 1582556514881692819], [6 x i64] zeroinitializer], [480 x i8] undef }, align 8, !dbg !114
```
This patch, as suggested by Andy, fixes at least this behavior of clang.