### PR TITLE
NodeJS bindings - worker threads error demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,5 @@ jobs:
               )
             fi
         fi
+    - name: Worker threads error
+      run: node bindings/node.js/worker-threads.js

--- a/bindings/node.js/runnable.js
+++ b/bindings/node.js/runnable.js
@@ -2,7 +2,7 @@
 
 console.log("testing...");
 
-const blst = require("blst");
+const blst = require("./blst.node");
 
 var msg = "assertion";          // this what we're signing
 var DST = "MY-DST";             // domain separation tag

--- a/bindings/node.js/worker-threads.js
+++ b/bindings/node.js/worker-threads.js
@@ -1,0 +1,8 @@
+const { Worker } = require("worker_threads");
+
+// Create two workers so blst.node is imported twice to trigger the error
+// blst/bindings/node.js$ node worker-threads.js
+// Error: Module did not self-register: 'blst/bindings/node.js/blst.node'.
+
+const worker1 = new Worker("./runnable.js");
+const worker2 = new Worker("./runnable.js");


### PR DESCRIPTION
Current NodeJS bindings throw an error when run on more than one worker, or in the main thread + 1 worker. 

To achieve a comparable level of performance closer to the other bindings it's very important to be able to multi-thread BLS signature verification

```
Run node bindings/node.js/worker-threads.js

events.js:291
      throw er; // Unhandled 'error' event
      ^
Error: Cannot find module '/home/runner/work/blst/blst/runnable.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at MessagePort.<anonymous> (internal/main/worker_thread.js:164:24)
    at MessagePort.emit (events.js:314:20)
    at MessagePort.onmessage (internal/worker/io.js:80:8)
    at MessagePort.exports.emitMessage (internal/per_context/messageport.js:11:10)
Emitted 'error' event on Worker instance at:
    at Worker.[kOnErrorMessage] (internal/worker.js:242:10)
    at Worker.[kOnMessage] (internal/worker.js:252:37)
    at MessagePort.<anonymous> (internal/worker.js:168:57)
    at MessagePort.emit (events.js:314:20)
    at MessagePort.onmessage (internal/worker/io.js:80:8)
    at MessagePort.exports.emitMessage (internal/per_context/messageport.js:11:10)
    at Worker.[kOnExit] (internal/worker.js:224:5)
    at Worker.<computed>.onexit (internal/worker.js:165:20) {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```
https://github.com/supranational/blst/pull/47/checks?check_run_id=1530217010#step:10:12

This PR is meant to demo said error with the simplest setup to hopefully assist in finding a solution.

This issue hints at a possible cause and solution but it escapes may knowledge https://github.com/nodejs/node/issues/21783#issuecomment-429637117