### PR TITLE
Update blst_wrap.py

### DIFF
--- a/bindings/node.js/blst_wrap.py
+++ b/bindings/node.js/blst_wrap.py
@@ -2,39 +2,55 @@ import sys
 import subprocess
 import re
 import shutil
+import os
+import os.path
+
+pythonScript = sys.argv[0]
+# ../blst.swg
+SOURCE_SWIG_FILE = sys.argv[1]
+# <(INTERMEDIATE_DIR)/blst_wrap.cpp
+# Example (Github actions): /home/runner/work/blst-ts/blst-ts/blst/bindings/node.js/build/Release/obj.target/blst/geni/blst_wrap.cpp
+BLST_WRAP_CPP_TARGET = sys.argv[2]
+BLST_WRAP_CPP_PREBUILD = os.getenv('BLST_WRAP_CPP_PREBUILD')
+
+print("SOURCE_SWIG_FILE", SOURCE_SWIG_FILE)
+print("BLST_WRAP_CPP_TARGET", BLST_WRAP_CPP_TARGET)
+print("BLST_WRAP_CPP_PREBUILD", BLST_WRAP_CPP_PREBUILD)
+
+
+if BLST_WRAP_CPP_PREBUILD:
+    if os.path.isfile(BLST_WRAP_CPP_PREBUILD):
+        print("Copying and using BLST_WRAP_CPP_PREBUILD")
+        shutil.copyfile(BLST_WRAP_CPP_PREBUILD, BLST_WRAP_CPP_TARGET)
+        sys.exit(0)
+    else:
+        print("BLST_WRAP_CPP_TARGET not found, building from src")
+else:
+    print("BLST_WRAP_CPP_TARGET not set, building from src")
+
 
 try:
     version = subprocess.check_output(["swig", "-version"]).decode('ascii')
+    print(version)
     v = re.search(r'SWIG Version ([0-9]+)', version)
     if v and int(v.group(1)) >= 4:
+        print("Running SWIG...")
         subprocess.check_call(["swig", "-c++", "-javascript",
                                        "-node", "-DV8_VERSION=0x060000",
-                                       "-o", sys.argv[2], sys.argv[1]])
+                                       "-o", BLST_WRAP_CPP_TARGET, SOURCE_SWIG_FILE])
     else:
-        raise OSError(2, "unsupported swig version")
-    sys.exit(0)
+        print("Unsupported swig version")
+        sys.exit(128)
+
 except OSError as e:
-    if e.errno != 2:    # not "no such file or directory"
-        raise e
-    sys.exit(e.errno)   # or do something else, say ...
+    if e.errno == 2:    # "no such file or directory"
+        print("SWIG not installed", e)
+    else:
+        print("Error checking SWIG version", e)
+    sys.exit(e.errno)
 
-here = re.split(r'[/\\](?=[^/\\]*$)', sys.argv[0])
-if len(here) == 1:
-    here.insert(0, '.')
 
-version = subprocess.check_output(["node", "--version"]).decode('ascii')
-v = re.match(r'^v([0-9]+)', version)
-if v:
-    maj = int(v.group(1))
-    if maj >= 16:
-        pass
-    elif maj >= 12:
-        pre_gen = "blst_wrap.v12.cpp"
-    elif maj >= 8:
-        pre_gen = "blst_wrap.v8.cpp"
+if BLST_WRAP_CPP_PREBUILD:
+    print("Copying built BLST_WRAP_CPP_TARGET to BLST_WRAP_CPP_PREBUILD")
+    shutil.copyfile(BLST_WRAP_CPP_TARGET, BLST_WRAP_CPP_PREBUILD)
 
-try:
-    shutil.copyfile("{}/{}".format(here[0],pre_gen), sys.argv[2])
-except NameError:
-    sys.stderr.write("unsupported 'node --version': {}".format(version))
-    sys.exit(2)         # "no such file or directory"


### PR DESCRIPTION
The setup looks for `BLST_WRAP_CPP_PREBUILD` env variable and if defined:
- if file exists grabs it and skips swig
- if file does not exist builds with swig and copies the result to `BLST_WRAP_CPP_PREBUILD`

Opening this PR in case other builders may benefit from this setup and so we can get a clean git submodule without the need to copy a patch