### PR TITLE
bindings/blst.{hpp,swg}: shift memory management to JVM GC.

### DIFF
--- a/bindings/blst.hpp
+++ b/bindings/blst.hpp
@@ -131,7 +131,7 @@ private:
 
 public:
     P1() { memset(&point, 0, sizeof(point)); }
-    P1(SecretKey& sk) { blst_sk_to_pk_in_g1(&point, &sk.key); }
+    P1(const SecretKey& sk) { blst_sk_to_pk_in_g1(&point, &sk.key); }
     P1(const byte *in)
     {   blst_p1_affine a;
         BLST_ERROR err = blst_p1_deserialize(&a, in);
@@ -271,7 +271,7 @@ private:
 
 public:
     P2() { memset(&point, 0, sizeof(point)); }
-    P2(SecretKey& sk) { blst_sk_to_pk_in_g2(&point, &sk.key); }
+    P2(const SecretKey& sk) { blst_sk_to_pk_in_g2(&point, &sk.key); }
     P2(const byte *in)
     {   blst_p2_affine a;
         BLST_ERROR err = blst_p2_deserialize(&a, in);
@@ -459,6 +459,7 @@ public:
     {   delete[] static_cast<uint64_t*>(ptr);   }
 #endif
 
+#if !defined(SWIG) || !defined(SWIGJAVA)
     Pairing(bool hash_or_encode, const byte* DST, size_t DST_len)
     {   init(hash_or_encode, DST, DST_len);   }
     Pairing(bool hash_or_encode, const std::string& DST)
@@ -472,6 +473,7 @@ public:
     }
 #endif
     ~Pairing() { delete[] blst_pairing_get_dst(*this); }
+#endif
 
     BLST_ERROR aggregate(const P1_Affine* pk, const P2_Affine* sig,
                          const byte* msg, size_t msg_len,

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -176,7 +176,8 @@
 // new objects allocate suitably sized long[] arrays from JVM heap,
 // references to which are then assigned to |swigCPtr| on the Java side.
 // And when passed back to JNI, |swigCPtr|s are dereferenced with
-// GetLongArrayElements...
+// GetLongArrayElements... And no destructors!
+%nodefaultdtor;
 %typemap(javabody) SWIGTYPE %{
   private transient long[] swigCPtr;
 
@@ -187,7 +188,6 @@
   public $javaclassname dup() { return new $javaclassname(swigCPtr.clone()); }
 %}
 %ignore dup;
-%nodefaultdtor;
 %typemap(javafinalize)  SWIGTYPE ""
 %typemap(javadestruct)  SWIGTYPE ""
 %typemap(javaconstruct) SWIGTYPE { this($imcall); }
@@ -239,7 +239,6 @@
         }
         return (Pairing *)ret;
     }
-    ~Pairing() { free($self); }
 }
 %typemap(out) blst::Pairing* {
     size_t sz = blst_pairing_sizeof();

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -22,14 +22,14 @@
 
 // some sorcery to allow assignments as output, e.g.
 //      hash = blst.encode_to_g1(b"foo")
-%typemap(in, numinputs=0) OBJECT *OUTPUT($1_basetype temp) { $1 = &temp; };
+%typemap(in, numinputs=0) OBJECT *OUTPUT($1_basetype temp) %{ $1 = &temp; %}
 %typemap(argout) OBJECT *OUTPUT {
     PyObject *obj = SWIG_NewPointerObj(memcpy(malloc(sizeof($1_basetype)),
                                               $1,sizeof($1_basetype)),
                                        $descriptor, SWIG_POINTER_NEW);
     $result = ($result==NULL) ? obj
                               : SWIG_Python_AppendOutput($result, obj);
-};
+}
 %apply OBJECT *OUTPUT {
     blst_p1        *out, blst_p1        *out_pk, blst_p1        *out_sig,
     blst_p1_affine *out, blst_p1_affine *out_pk, blst_p1_affine *out_sig,
@@ -37,10 +37,10 @@
     blst_p2_affine *out, blst_p2_affine *out_pk, blst_p2_affine *out_sig,
     blst_scalar    *out, blst_scalar    *out_SK,
     blst_fp12      *out
-};
+}
 
 // accept 'bytes' and 'bytearray' as inputs...
-%typemap(in) const byte* {
+%typemap(in) const byte* %{
     if (PyBytes_Check($input)) {
         char *buf;
         Py_ssize_t nbytes;
@@ -55,10 +55,10 @@
         SWIG_exception_fail(SWIG_TypeError, "in method '$symname', "
                                             "expecting 'bytes' or 'bytearray'");
     }
-}
+%}
 %typemap(freearg) const byte* ""
 
-%typemap(in) const byte[ANY] {
+%typemap(in) const byte[ANY] %{
     if (PyBytes_Check($input)) {
         char *buf;
         Py_ssize_t nbytes;
@@ -79,7 +79,7 @@
         SWIG_exception_fail(SWIG_TypeError, "in method '$symname', "
                                             "expecting 'bytes' or 'bytearray'");
     }
-}
+%}
 %typemap(freearg) const byte[ANY] ""
 
 %typemap(in) (const byte *STRING, size_t LENGTH) %{
@@ -144,13 +144,13 @@
 %}
 
 #ifdef __cplusplus
-%typemap(out) BLST_ERROR {
+%typemap(out) BLST_ERROR %{
     if ($1 != BLST_SUCCESS) {
         SWIG_exception(SWIG_ValueError, BLST_ERROR_str[$1]);
         SWIG_fail;
     }
     $result = SWIG_From_int($1);
-};
+%}
 
 // return |this|
 %typemap(out) SELF* OUTPUT %{ (void)$1; Py_INCREF($result = swig_obj[0]); %}
@@ -240,7 +240,7 @@
         return (Pairing *)ret;
     }
     ~Pairing() { free($self); }
-};
+}
 %typemap(out) blst::Pairing* {
     size_t sz = blst_pairing_sizeof();
     size_t SZ = (sz + arg2->size() + sizeof(jlong) - 1)/sizeof(jlong);
@@ -254,7 +254,7 @@
 %typemap(throws) BLST_ERROR %{
     SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException,
                                   BLST_ERROR_str[$1]);
-%};
+%}
 
 #if SWIG_VERSION < 0x040000
 %apply (char *STRING, size_t LENGTH) { (const byte *STRING, size_t LENGTH) }
@@ -264,11 +264,11 @@
 %apply signed char[] { const byte* }
 %typemap(in) const byte* %{
     $1 = ($1_ltype)JCALL(GetByteArrayElements, $input, 0);
-%};
+%}
 %typemap(argout)  const byte* ""
 %typemap(freearg) const byte* %{
     JCALL(ReleaseByteArrayElements, $input, (jbyte *)$1, JNI_ABORT);
-%};
+%}
 
 %apply const byte* { const byte[ANY] }
 %typemap(in) const byte[ANY] {
@@ -279,7 +279,7 @@
         return $null;
     }
     $1 = ($1_ltype)JCALL(GetByteArrayElements, $input, 0);
-};
+}
 
 // let users use 'java.math.BigInteger' as scalars
 %typemap(in) (const byte* scalar, size_t nbits) %{
@@ -300,14 +300,14 @@
     if ($1[$2-1] == 0)
         $2--;
     $2 *= 8;
-%};
+%}
 %typemap(jni)    (const byte* scalar, size_t nbits) "jbyteArray"
 %typemap(jtype)  (const byte* scalar, size_t nbits) "byte[]"
 %typemap(jstype) (const byte* scalar, size_t nbits) "java.math.BigInteger"
 %typemap(javain) (const byte* scalar, size_t nbits) "$javainput.toByteArray()"
 
 #ifdef __cplusplus
-%typemap(javaout) SELF* OUTPUT "{ $jnicall; return this; }"
+%typemap(javaout) SELF* OUTPUT { $jnicall; return this; }
 #endif
 
 #elif defined(SWIGJAVASCRIPT) && defined(SWIG_JAVASCRIPT_V8)
@@ -320,9 +320,9 @@
 #endif
 %}
 
-%typemap(throws) BLST_ERROR %{ SWIG_V8_Raise(BLST_ERROR_str[$1]); SWIG_fail; %};
+%typemap(throws) BLST_ERROR %{ SWIG_V8_Raise(BLST_ERROR_str[$1]); SWIG_fail; %}
 
-%typemap(in) const byte* {
+%typemap(in) const byte* %{
     if ($input->IsArrayBufferView()) {
         auto av = v8::Local<v8::ArrayBufferView>::Cast($input);
         auto buf = av->Buffer();
@@ -331,12 +331,12 @@
         SWIG_exception_fail(SWIG_TypeError, "in method '$symname', "
                                             "expecting <Buffer>");
     }
-};
+%}
 %typemap(argout)  const byte* ""
 %typemap(freearg) const byte* ""
 
 %apply const byte* { const byte[ANY] }
-%typemap(in) const byte[ANY] {
+%typemap(in) const byte[ANY] %{
     if ($input->IsArrayBufferView()) {
         auto av = v8::Local<v8::ArrayBufferView>::Cast($input);
         if (av->ByteLength() != $1_dim0)
@@ -348,7 +348,7 @@
         SWIG_exception_fail(SWIG_TypeError, "in method '$symname', "
                                             "expecting <Buffer>");
     }
-};
+%}
 
 // let users use JavaScript <BigInt> and <Buffer> as scalars
 %typemap(in) (const byte* scalar, size_t nbits) %{
@@ -388,9 +388,9 @@
         SWIG_exception_fail(SWIG_TypeError, "in method '$symname', "
                                             "expecting <Buffer> or <BigInt>");
     }
-%};
+%}
 
-%typemap(in) (const byte *STRING, size_t LENGTH) {
+%typemap(in) (const byte *STRING, size_t LENGTH) %{
     if ($input->IsArrayBufferView()) {
         auto av = v8::Local<v8::ArrayBufferView>::Cast($input);
         auto buf = av->Buffer();
@@ -405,7 +405,7 @@
         SWIG_exception_fail(SWIG_TypeError, "in method '$symname', "
                                             "expecting <Buffer> or <String>");
     }
-};
+%}
 
 // return |this|
 %typemap(out) SELF* OUTPUT %{ (void)$1; $result = args.Holder(); %}
@@ -430,12 +430,10 @@
        (const byte *aug,    size_t aug_len),
        (const byte *IKM,    size_t IKM_len),
        (const byte *info,   size_t info_len)
-};
+}
 
 // some sorcery to return byte[] from serialization methods
-%typemap(in, numinputs=0) byte out[ANY] (byte temp[$1_dim0]) {
-    $1 = temp;
-};
+%typemap(in, numinputs=0) byte out[ANY] (byte temp[$1_dim0]) %{ $1 = temp; %}
 %typemap(argout) byte out[ANY] {
 #if defined(SWIGPYTHON)
     PyObject *obj = SWIG_FromCharPtrAndSize((char *)$1, $1_dim0);
@@ -456,13 +454,13 @@
     if ($result == NULL)
         $result = SWIG_FromCharPtrAndSize((char *)$1, $1_dim0);
 #endif
-};
+}
 %typemap(freearg) byte out[ANY] ""
 #ifdef SWIGJAVA
 %typemap(jni)     byte out[ANY] "jbyteArray"
 %typemap(jtype)   byte out[ANY] "byte[]"
 %typemap(jstype)  byte out[ANY] "byte[]"
-%typemap(javaout) byte out[ANY] "{ return $jnicall; }"
+%typemap(javaout) byte out[ANY] { return $jnicall; }
 #endif
 %apply byte out[ANY] {
     void to_bendian,    void blst_bendian_from_scalar,
@@ -473,10 +471,10 @@
                         void blst_p2_compress,  void blst_p2_affine_compress,
     void blst_sk_to_pk2_in_g1,  void blst_sign_pk2_in_g1,
     void blst_sk_to_pk2_in_g2,  void blst_sign_pk2_in_g2
-};
+}
 
 #ifdef __cplusplus
-%apply const std::string& { const std::string* };
+%apply const std::string& { const std::string* }
 
 #pragma SWIG nowarn=509,516
 
@@ -502,7 +500,7 @@
     blst::P1* dbl,          blst::P2* dbl,
     blst::PT* mul,          blst::PT* sqr,
     blst::PT* final_exp
-};
+}
 
 typedef enum {
     BLST_SUCCESS = 0,
@@ -553,7 +551,7 @@ extern const blst::P2_Affine BLS12_381_NEG_G2;
         if (dst != NULL) free(dst);
         free($self);
     }
-};
+}
 #endif
 
 %begin %{

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -170,6 +170,87 @@
 %include "arrays_java.i"
 %javaconst(1);
 
+#ifdef __cplusplus
+// Extensive sorcery to shift memory management to JVM GC. General idea is
+// to use Java long[] as opaque storage for blst data. Methods that return
+// new objects allocate suitably sized long[] arrays from JVM heap,
+// references to which are then assigned to |swigCPtr| on the Java side.
+// And when passed back to JNI, |swigCPtr|s are dereferenced with
+// GetLongArrayElements...
+%typemap(javabody) SWIGTYPE %{
+  private transient long[] swigCPtr;
+
+  protected $javaclassname(long[] cPtr) { swigCPtr = cPtr; }
+
+  protected static long[] getCPtr($javaclassname obj) { return obj.swigCPtr; }
+
+  public $javaclassname dup() { return new $javaclassname(swigCPtr.clone()); }
+%}
+%ignore dup;
+%nodefaultdtor;
+%typemap(javafinalize)  SWIGTYPE ""
+%typemap(javadestruct)  SWIGTYPE ""
+%typemap(javaconstruct) SWIGTYPE { this($imcall); }
+%typemap(jni)           SWIGTYPE, SWIGTYPE&, SWIGTYPE* "jlongArray"
+%typemap(jtype)         SWIGTYPE, SWIGTYPE&, SWIGTYPE* "long[]"
+%typemap(javaout)       SWIGTYPE, SWIGTYPE&, SWIGTYPE* {
+    return new $javaclassname($jnicall);
+}
+%typemap(in)            SWIGTYPE&, SWIGTYPE* %{
+    $1 = ($1_ltype)JCALL(GetLongArrayElements, $input, 0);
+%}
+%typemap(out)           SWIGTYPE&, SWIGTYPE* %{
+    if ($1 != $null) {
+        size_t sz = (sizeof($1_basetype) + sizeof(jlong) - 1)/sizeof(jlong);
+        $result = JCALL(NewLongArray, sz);
+        if ($result != $null)
+            JCALL(SetLongArrayRegion, $result, 0, sz, (const jlong *)$1);
+    }
+%}
+%typemap(out)           SWIGTYPE {
+    size_t sz = (sizeof($1_basetype) + sizeof(jlong) - 1)/sizeof(jlong);
+    $result = JCALL(NewLongArray, sz);
+    if ($result != $null)
+        JCALL(SetLongArrayRegion, $result, 0, sz, (const jlong *)&$1);
+}
+%typemap(newfree)       SWIGTYPE* "delete $1;"
+%typemap(freearg)       SWIGTYPE&, SWIGTYPE* %{
+    JCALL(ReleaseLongArrayElements, $input, (jlong *)$1, 0);
+%}
+%typemap(freearg) const SWIGTYPE&, const SWIGTYPE* %{
+    JCALL(ReleaseLongArrayElements, $input, (jlong *)$1, JNI_ABORT);
+%}
+%typemap(freearg) const std::string& ""
+
+// I wish |jenv| was available in the constructor, so that NewLongArray
+// could be called at once, without having to resort to matching
+// %typemap(out)...
+%extend blst::Pairing {
+    Pairing(bool hash_or_encode, const std::string& DST)
+    {   size_t sz = blst_pairing_sizeof();
+        size_t SZ = (sz + DST.size() + sizeof(jlong) - 1)/sizeof(jlong);
+        blst_pairing *ret = (blst_pairing *)malloc(SZ*sizeof(jlong));
+        if (DST.size() != 0) {
+            byte *dst = (byte *)ret + sz;
+            memcpy(dst, DST.data(), DST.size());
+            blst_pairing_init(ret, hash_or_encode, dst, DST.size());
+        } else {
+            blst_pairing_init(ret, hash_or_encode, NULL, 0);
+        }
+        return (Pairing *)ret;
+    }
+    ~Pairing() { free($self); }
+};
+%typemap(out) blst::Pairing* {
+    size_t sz = blst_pairing_sizeof();
+    size_t SZ = (sz + arg2->size() + sizeof(jlong) - 1)/sizeof(jlong);
+    $result = JCALL(NewLongArray, SZ);
+    if ($result != $null)
+        JCALL(SetLongArrayRegion, $result, 0, SZ, (const jlong *)$1);
+}
+%typemap(newfree) blst::Pairing* "free($1);"
+#endif
+
 %typemap(throws) BLST_ERROR %{
     SWIG_JavaThrowException(jenv, SWIG_JavaRuntimeException,
                                   BLST_ERROR_str[$1]);


### PR DESCRIPTION
So far Java interface was reliant on deprecated finalize() method to
free memory allocated by blst. Now we use Java long[] as opaque
storage for blst structures.

@Nashatyrev, @cemozerr, could you have a look at this? Not necessarily at C++ part, as main question is if auto-generated .java code is sensible. In other words, execute `bindings/java/run.me` and skim through newly created `bindings/java/*.java`. Please:-)
