### PR TITLE
Add null check to getCPtr

### DIFF
--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -244,6 +244,9 @@ import java.nio.file.*;
 %typemap(in)            SWIGTYPE&, SWIGTYPE* %{
     $1 = ($1_ltype)JCALL(GetLongArrayElements, $input, 0);
 %}
+%typemap(in)      const SWIGTYPE&, const SWIGTYPE* %{
+    if ($input) $1 = ($1_ltype)JCALL(GetLongArrayElements, $input, 0);
+%}
 %typemap(out)           SWIGTYPE&, SWIGTYPE* %{
     if ($1 != $null) {
         size_t sz = (sizeof($1_basetype) + sizeof(jlong) - 1)/sizeof(jlong);
@@ -263,7 +266,7 @@ import java.nio.file.*;
     JCALL(ReleaseLongArrayElements, $input, (jlong *)$1, 0);
 %}
 %typemap(freearg) const SWIGTYPE&, const SWIGTYPE* %{
-    JCALL(ReleaseLongArrayElements, $input, (jlong *)$1, JNI_ABORT);
+    if ($input) JCALL(ReleaseLongArrayElements, $input, (jlong *)$1, JNI_ABORT);
 %}
 %typemap(freearg) const std::string& ""
 

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -226,12 +226,11 @@ import java.nio.file.*;
 %typemap(javadestruct)  SWIGTYPE ""
 
 %typemap(javabody)      SWIGTYPE %{
-  private static final long[] NULL = new long[0];
   private transient long[] swigCPtr;
 
   protected $javaclassname(long[] cPtr) { swigCPtr = cPtr; }
 
-  protected static long[] getCPtr($javaclassname obj) { return obj != null ? obj.swigCPtr : NULL; }
+  protected static long[] getCPtr($javaclassname obj) { return obj != null ? obj.swigCPtr : null; }
 
   public $javaclassname dup() { return new $javaclassname(swigCPtr.clone()); }
 %}

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -226,11 +226,12 @@ import java.nio.file.*;
 %typemap(javadestruct)  SWIGTYPE ""
 
 %typemap(javabody)      SWIGTYPE %{
+  private static final long[] NULL = new long[0];
   private transient long[] swigCPtr;
 
   protected $javaclassname(long[] cPtr) { swigCPtr = cPtr; }
 
-  protected static long[] getCPtr($javaclassname obj) { return obj.swigCPtr; }
+  protected static long[] getCPtr($javaclassname obj) { return obj != null ? obj.swigCPtr : NULL; }
 
   public $javaclassname dup() { return new $javaclassname(swigCPtr.clone()); }
 %}

--- a/bindings/java/runnable.java
+++ b/bindings/java/runnable.java
@@ -25,9 +25,8 @@ public class runnable {
             throw new java.lang.RuntimeException("disaster");
         var ctx = new Pairing(true, DST);
         ctx.aggregate(_pk, _sig, msg, pk_for_wire);
-        ctx.aggregate(_pk, null, msg, pk_for_wire);
         ctx.commit();
-        if (ctx.finalverify())
+        if (!ctx.finalverify())
             throw new java.lang.RuntimeException("disaster");
         System.out.println("OK");
     }

--- a/bindings/java/runnable.java
+++ b/bindings/java/runnable.java
@@ -25,8 +25,9 @@ public class runnable {
             throw new java.lang.RuntimeException("disaster");
         var ctx = new Pairing(true, DST);
         ctx.aggregate(_pk, _sig, msg, pk_for_wire);
+        ctx.aggregate(_pk, null, msg, pk_for_wire);
         ctx.commit();
-        if (!ctx.finalverify())
+        if (ctx.finalverify())
             throw new java.lang.RuntimeException("disaster");
         System.out.println("OK");
     }


### PR DESCRIPTION
When verifying aggregate signatures using the Java wrapper there's a sequence of calls to `Pairing.aggregate`, the first of which has all non-null values but subsequent calls should pass `null` for the `P2_Affline sig` parameter. In Teku this comes out as https://github.com/ConsenSys/teku/blob/d585e7f1dc25333defe92e9f1d47b08b122533a5/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java#L78 that method being called in a loop by the `verify(List<PublicKeyMessagePair>)` method a little below.

However, because `Pairing.aggregate` calls `P2_Affine.getCPtr(sig)` a `NullPointerException` results when `sig` is `null`.  If my understanding is right, `getCPtr` should return a 0 length `long[]` to represent null.  I've made that change (used a static final to avoid allocating a new empty array on each call) and the Teku tests are now passing.

I'm more than happy to be told there's a better way of doing this though.