### PR TITLE
Change non-breaking hyphen to normal dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Windows (Visual C)
 \some\where\build.bat
 ```
 
-If final application crashes with an "illegal instruction" exception [after copying to another system], pass `‑D__BLST_PORTABLE__` on `build.sh` command line. If you don't use build.sh, complement the `CFLAGS` environment variable with the said command line option. If you compile a Go application, you will need to modify the `CGO_CFLAGS` variable instead. And if you compile a Rust application, you can pass `‑‑features portable` to `cargo build`. Alternatively, if you compile on an older Intel system, but will execute application on a newer one, consider instead passing `‑‑features force‑adx` for better performance.
+If final application crashes with an "illegal instruction" exception [after copying to another system], pass `-D__BLST_PORTABLE__` on `build.sh` command line. If you don't use build.sh, complement the `CFLAGS` environment variable with the said command line option. If you compile a Go application, you will need to modify the `CGO_CFLAGS` variable instead. And if you compile a Rust application, you can pass `‑‑features portable` to `cargo build`. Alternatively, if you compile on an older Intel system, but will execute application on a newer one, consider instead passing `‑‑features force‑adx` for better performance.
 
 ## Language-specific notes
 


### PR DESCRIPTION
The original has a non-breaking hyphen (unicode 2011) in `-D__BLST_PORTABLE__`, which causes it to be ignored by the compiler when cut and pasted. Better to substitute with an ASCII hyphen.