### PR TITLE
bindings/rust/src/bindings.rs: resolve deref_nullptr warning.

### DIFF
--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -32,7 +32,7 @@ fn bindgen_test_layout_blst_scalar() {
         concat!("Alignment of ", stringify!(blst_scalar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_scalar>())).b as *const _ as usize },
+        offsetof!(blst_scalar, b),
         0usize,
         concat!(
             "Offset of field: ",
@@ -60,7 +60,7 @@ fn bindgen_test_layout_blst_fr() {
         concat!("Alignment of ", stringify!(blst_fr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_fr>())).l as *const _ as usize },
+        offsetof!(blst_fr, l),
         0usize,
         concat!(
             "Offset of field: ",
@@ -88,7 +88,7 @@ fn bindgen_test_layout_blst_fp() {
         concat!("Alignment of ", stringify!(blst_fp))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_fp>())).l as *const _ as usize },
+        offsetof!(blst_fp, l),
         0usize,
         concat!(
             "Offset of field: ",
@@ -116,7 +116,7 @@ fn bindgen_test_layout_blst_fp2() {
         concat!("Alignment of ", stringify!(blst_fp2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_fp2>())).fp as *const _ as usize },
+        offsetof!(blst_fp2, fp),
         0usize,
         concat!(
             "Offset of field: ",
@@ -144,7 +144,7 @@ fn bindgen_test_layout_blst_fp6() {
         concat!("Alignment of ", stringify!(blst_fp6))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_fp6>())).fp2 as *const _ as usize },
+        offsetof!(blst_fp6, fp2),
         0usize,
         concat!(
             "Offset of field: ",
@@ -172,7 +172,7 @@ fn bindgen_test_layout_blst_fp12() {
         concat!("Alignment of ", stringify!(blst_fp12))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_fp12>())).fp6 as *const _ as usize },
+        offsetof!(blst_fp12, fp6),
         0usize,
         concat!(
             "Offset of field: ",
@@ -411,7 +411,7 @@ fn bindgen_test_layout_blst_p1() {
         concat!("Alignment of ", stringify!(blst_p1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p1>())).x as *const _ as usize },
+        offsetof!(blst_p1, x),
         0usize,
         concat!(
             "Offset of field: ",
@@ -421,7 +421,7 @@ fn bindgen_test_layout_blst_p1() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p1>())).y as *const _ as usize },
+        offsetof!(blst_p1, y),
         48usize,
         concat!(
             "Offset of field: ",
@@ -431,7 +431,7 @@ fn bindgen_test_layout_blst_p1() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p1>())).z as *const _ as usize },
+        offsetof!(blst_p1, z),
         96usize,
         concat!(
             "Offset of field: ",
@@ -460,7 +460,7 @@ fn bindgen_test_layout_blst_p1_affine() {
         concat!("Alignment of ", stringify!(blst_p1_affine))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p1_affine>())).x as *const _ as usize },
+        offsetof!(blst_p1_affine, x),
         0usize,
         concat!(
             "Offset of field: ",
@@ -470,7 +470,7 @@ fn bindgen_test_layout_blst_p1_affine() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p1_affine>())).y as *const _ as usize },
+        offsetof!(blst_p1_affine, y),
         48usize,
         concat!(
             "Offset of field: ",
@@ -561,7 +561,7 @@ fn bindgen_test_layout_blst_p2() {
         concat!("Alignment of ", stringify!(blst_p2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p2>())).x as *const _ as usize },
+        offsetof!(blst_p2, x),
         0usize,
         concat!(
             "Offset of field: ",
@@ -571,7 +571,7 @@ fn bindgen_test_layout_blst_p2() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p2>())).y as *const _ as usize },
+        offsetof!(blst_p2, y),
         96usize,
         concat!(
             "Offset of field: ",
@@ -581,7 +581,7 @@ fn bindgen_test_layout_blst_p2() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p2>())).z as *const _ as usize },
+        offsetof!(blst_p2, z),
         192usize,
         concat!(
             "Offset of field: ",
@@ -610,7 +610,7 @@ fn bindgen_test_layout_blst_p2_affine() {
         concat!("Alignment of ", stringify!(blst_p2_affine))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p2_affine>())).x as *const _ as usize },
+        offsetof!(blst_p2_affine, x),
         0usize,
         concat!(
             "Offset of field: ",
@@ -620,7 +620,7 @@ fn bindgen_test_layout_blst_p2_affine() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<blst_p2_affine>())).y as *const _ as usize },
+        offsetof!(blst_p2_affine, y),
         96usize,
         concat!(
             "Offset of field: ",

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -24,6 +24,15 @@ fn da_pool() -> ThreadPool {
     unsafe { (*POOL).lock().unwrap().clone() }
 }
 
+#[cfg(test)]
+macro_rules! offsetof {
+    ($type:ty, $field:tt) => {
+        unsafe {
+            let v = std::mem::MaybeUninit::<$type>::uninit().assume_init();
+            (&v.$field as *const _ as usize) - (&v as *const _ as usize)
+        }
+    };
+}
 include!("bindings.rs");
 
 impl PartialEq for blst_p1 {

--- a/build/bindings_trim.pl
+++ b/build/bindings_trim.pl
@@ -8,17 +8,15 @@ for (my $i = 0; $i <= $#file; $i++) {
     if (@file[$i] =~ m/struct\s+blst_p[12]/) {
         @file[$i-1] =~ s/,\s*PartialEq//;
     } elsif (@file[$i] =~ m/struct\s+blst_fp12/) {
-        @file[$i-1] =~ s/,\s*Default//;
-        @file[$i-1] =~ s/,\s*PartialEq//;
+        @file[$i-1] =~ s/,\s*(?:Default|PartialEq)//g;
     } elsif (@file[$i] =~ m/struct\s+(blst_pairing|blst_uniq)/) {
-        @file[$i-1] =~ s/,\s*Copy//;
-        @file[$i-1] =~ s/,\s*Clone//;
-        @file[$i-1] =~ s/,\s*Eq//;
-        @file[$i-1] =~ s/,\s*PartialEq//;
+        @file[$i-1] =~ s/,\s*(?:Copy|Clone|Eq|PartialEq)//g;
     } elsif (@file[$i] =~ m/struct\s+blst_scalar/) {
         @file[$i-1] =~ s/,\s*Copy//;
         @file[$i-1] =~ s/\)/, Zeroize\)/;
         splice @file, $i, 0, "#[zeroize(drop)]\n"; $i++;
+    } elsif (@file[$i] =~ s/unsafe\s*\{\s*&\(\*\(::std::ptr::null::<(\w+)>\(\)\)\)\.(\w+).*\}/offsetof!($1, $2)/) {
+        # replacement is done already
     }
 }
 


### PR DESCRIPTION
To Rust people on the watch list. Does this look proper? Question is mostly about the `offsetof` macro. Can it be problematic ~to~ for you? For example, cause a conflict? For reference, background is that Rust 1.53 started complaining about code auto-generated by bindgen.