### PR TITLE
Add (*P{1,2}) FromAffine to Go bindings

### DIFF
--- a/bindings/go/blst.go
+++ b/bindings/go/blst.go
@@ -1584,10 +1584,8 @@ func (points P1s) ToAffine() P1Affines {
 	return P1sToAffine([]*P1{&points[0], nil}, len(points))
 }
 
-func (pa *P1Affine) ToProjective() *P1 {
-	var p P1
-	C.blst_p1_from_affine(&p, pa)
-	return &p
+func (p *P1) FromAffine(pa *P1Affine) {
+	C.blst_p1_from_affine(p, pa)
 }
 
 //
@@ -1812,10 +1810,8 @@ func (points P2s) ToAffine() P2Affines {
 	return P2sToAffine([]*P2{&points[0], nil}, len(points))
 }
 
-func (pa *P2Affine) ToProjective() *P2 {
-	var p P2
-	C.blst_p2_from_affine(&p, pa)
-	return &p
+func (p *P2) FromAffine(pa *P2Affine) {
+	C.blst_p2_from_affine(p, pa)
 }
 
 //

--- a/bindings/go/blst.go
+++ b/bindings/go/blst.go
@@ -1584,6 +1584,12 @@ func (points P1s) ToAffine() P1Affines {
 	return P1sToAffine([]*P1{&points[0], nil}, len(points))
 }
 
+func (pa *P1Affine) ToProjective() *P1 {
+	var p P1
+	C.blst_p1_from_affine(&p, pa)
+	return &p
+}
+
 //
 // Batch addition
 //
@@ -1804,6 +1810,12 @@ func P2sToAffine(points []*P2, optional ...int) P2Affines {
 
 func (points P2s) ToAffine() P2Affines {
 	return P2sToAffine([]*P2{&points[0], nil}, len(points))
+}
+
+func (pa *P2Affine) ToProjective() *P2 {
+	var p P2
+	C.blst_p2_from_affine(&p, pa)
+	return &p
 }
 
 //

--- a/bindings/go/blst_px.tgo
+++ b/bindings/go/blst_px.tgo
@@ -1,4 +1,3 @@
-
 //
 // Serialization/Deserialization.
 //
@@ -134,6 +133,12 @@ func (points P1s) ToAffine() P1Affines {
     return P1sToAffine([]*P1{&points[0], nil}, len(points))
 }
 
+func (pa *P1Affine) ToProjective() *P1 {
+    var p P1
+    C.blst_p1_from_affine(&p, pa)
+    return &p
+}
+
 //
 // Batch addition
 //
@@ -220,4 +225,3 @@ func EncodeToG1(msg []byte, dst []byte,
                             augC, C.size_t(len(aug)))
     return &q
 }
-

--- a/bindings/go/blst_px.tgo
+++ b/bindings/go/blst_px.tgo
@@ -133,10 +133,8 @@ func (points P1s) ToAffine() P1Affines {
     return P1sToAffine([]*P1{&points[0], nil}, len(points))
 }
 
-func (pa *P1Affine) ToProjective() *P1 {
-    var p P1
-    C.blst_p1_from_affine(&p, pa)
-    return &p
+func (p *P1) FromAffine(pa *P1Affine) {
+    C.blst_p1_from_affine(p, pa)
 }
 
 //


### PR DESCRIPTION
The affine -> ~~projective~~ Jacobian conversion is useful, especially when manipulating aggregates.
It's also defined in C already, so this exposes it in the go bindings.