### PR TITLE
feat: export fp12_raise_to_z

### DIFF
--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -391,6 +391,10 @@ extern "C" {
     pub fn blst_fp12_cyclotomic_sqr(ret: *mut blst_fp12, a: *const blst_fp12);
 }
 extern "C" {
+    pub fn blst_fp12_raise_to_z(ret: *mut blst_fp12, a: *const blst_fp12);
+}
+
+extern "C" {
     pub fn blst_fp12_mul(ret: *mut blst_fp12, a: *const blst_fp12, b: *const blst_fp12);
 }
 extern "C" {

--- a/src/pairing.c
+++ b/src/pairing.c
@@ -417,3 +417,7 @@ void blst_precompute_lines(vec384fp6 Qlines[68], const POINTonE2_affine *Q)
 void blst_miller_loop_lines(vec384fp12 ret, const vec384fp6 Qlines[68],
                                             const POINTonE1_affine *P)
 {   miller_loop_lines(ret, Qlines, P);   }
+
+void blst_fp12_raise_to_z(vec384fp12 ret, const vec384fp12 a)
+{   raise_to_z(ret, a);   }
+


### PR DESCRIPTION
I need this to implement a subgroup check in `fp12`