### PR TITLE
Fix a failing compilation in certain scenarios

### DIFF
--- a/src/sha256.h
+++ b/src/sha256.h
@@ -7,6 +7,7 @@
 #define __BLS12_381_ASM_SHA256_H__
 
 #include <stddef.h>
+#include "./vect.h"
 
 #if (defined(__x86_64__) || defined(__x86_64) || defined(_M_X64)) && \
      defined(__SHA__) /* -msha */ && !defined(__BLST_PORTABLE__)


### PR DESCRIPTION
The `sha256.h` uses the `static inline void vec_zero(void *ret, size_t num)` function defined `vect.h`, but this header is not included in `sha256.h`, so the code can be compiled only when the headers are included in specific order.

Including `vect.h` in `sha256.h` resolves the issue.