### PR TITLE
Allow loading the native library from a custom resource path

### DIFF
--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -350,8 +350,9 @@ import java.nio.file.*;
                                 + "/" + System.getProperty("os.arch")
                                 + "/" + libName;
     static {
-        InputStream res = $imclassname.class.getResourceAsStream(
-                        System.getProperty("supranational.blst.jniResource", resName));
+        Class<?> imClazz = $imclassname.class;
+        InputStream res = imClazz.getResourceAsStream(
+                        System.getProperty(imClazz.getPackageName() + ".jniResource", resName));
         if (res == null) {
             try {
                 System.loadLibrary("$module");


### PR DESCRIPTION
This makes the native library loading significantly more flexible. In particular, applications can embed native components built for both optimised and portable profiles and dynamically select which to load at runtime.