### PR TITLE
rust: remove zeroize version upper-bound

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -42,8 +42,7 @@ which = "^4.0"
 glob = "0.3"
 
 [dependencies]
-zeroize = { version = "^1.1, <1.4", features = ["zeroize_derive"] }
-zeroize_derive = "<1.2"
+zeroize = { version = "^1.1", features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 threadpool = "^1.8.1"


### PR DESCRIPTION
In commit https://github.com/supranational/blst/commit/47861e76c063a67a9de76efd91f7eb21b5f8985d an upper bound of `<1.4` was added to the `zeroize` dependency in order to maintain a lower minimum supported Rust version (MSRV).

I think we should remove this bound, because it prevents users of zeroize v1.4+ from using blst v0.3.7. Due to how Cargo does dependency resolution, it is impossible for a crate to depend on two semver-compatible versions of the same crate, i.e. two v1.x versions of zeroize (see this cargo issue for details: https://github.com/rust-lang/cargo/issues/6584).

In contrast, anyone wanting to use blst with an older Rust compiler can continue to do so by manually pinning their version of `zeroize` at an older version `<1.4`, so no functionality is lost by removing the bound.

The only thing that will stop working is running `cargo build` or `cargo test` _directly_ on `blst` with an old compiler version. I suspect this might break CI, but will devise a fix once I see if it fails.