### PR TITLE
Don't try to use ADX assembly on 32-bit

### DIFF
--- a/src/vect.h
+++ b/src/vect.h
@@ -69,7 +69,7 @@ typedef limb_t bool_t;
 /*
  * Assembly subroutines...
  */
-#if defined(__ADX__) /* e.g. -march=broadwell */ && !defined(__BLST_PORTABLE__)
+#if defined(__ADX__) /* e.g. -march=broadwell */ && !defined(__BLST_PORTABLE__) && !defined(__BLST_NO_ASM__)
 # define mul_mont_sparse_256 mulx_mont_sparse_256
 # define sqr_mont_sparse_256 sqrx_mont_sparse_256
 # define from_mont_256 fromx_mont_256


### PR DESCRIPTION
It's possible to use a 32-bit OS on an ADX CPU (for example when doing continuous integration).

In that case we need to guard the assembly routine with `!defined(__BLST_NO_ASM__)`

![image](https://user-images.githubusercontent.com/22738317/174571508-df72a7c2-f510-4bbf-9a80-a0eb96223ae6.png)
https://github.com/status-im/nimbus-eth2/runs/6957467084?check_suite_focus=true#step%3A16%3A1127=