### PR TITLE
Fix some "specific" typos

### DIFF
--- a/bindings/blst.h
+++ b/bindings/blst.h
@@ -83,7 +83,7 @@ bool blst_scalar_from_be_bytes(blst_scalar *out, const byte *in, size_t len);
 
 #ifndef SWIG
 /*
- * BLS12-381-specifc Fr operations.
+ * BLS12-381-specific Fr operations.
  */
 void blst_fr_add(blst_fr *ret, const blst_fr *a, const blst_fr *b);
 void blst_fr_sub(blst_fr *ret, const blst_fr *a, const blst_fr *b);
@@ -106,7 +106,7 @@ void blst_fr_from_scalar(blst_fr *ret, const blst_scalar *a);
 void blst_scalar_from_fr(blst_scalar *ret, const blst_fr *a);
 
 /*
- * BLS12-381-specifc Fp operations.
+ * BLS12-381-specific Fp operations.
  */
 void blst_fp_add(blst_fp *ret, const blst_fp *a, const blst_fp *b);
 void blst_fp_sub(blst_fp *ret, const blst_fp *a, const blst_fp *b);
@@ -130,7 +130,7 @@ void blst_fp_from_lendian(blst_fp *ret, const byte a[48]);
 void blst_lendian_from_fp(byte ret[48], const blst_fp *a);
 
 /*
- * BLS12-381-specifc Fp2 operations.
+ * BLS12-381-specific Fp2 operations.
  */
 void blst_fp2_add(blst_fp2 *ret, const blst_fp2 *a, const blst_fp2 *b);
 void blst_fp2_sub(blst_fp2 *ret, const blst_fp2 *a, const blst_fp2 *b);
@@ -145,7 +145,7 @@ void blst_fp2_inverse(blst_fp2 *ret, const blst_fp2 *a);
 bool blst_fp2_sqrt(blst_fp2 *ret, const blst_fp2 *a);
 
 /*
- * BLS12-381-specifc Fp12 operations.
+ * BLS12-381-specific Fp12 operations.
  */
 void blst_fp12_sqr(blst_fp12 *ret, const blst_fp12 *a);
 void blst_fp12_cyclotomic_sqr(blst_fp12 *ret, const blst_fp12 *a);
@@ -163,7 +163,7 @@ const blst_fp12 *blst_fp12_one();
 #endif  // SWIG
 
 /*
- * BLS12-381-specifc point operations.
+ * BLS12-381-specific point operations.
  */
 typedef struct { blst_fp x, y, z; } blst_p1;
 typedef struct { blst_fp x, y; } blst_p1_affine;

--- a/src/exports.c
+++ b/src/exports.c
@@ -19,7 +19,7 @@
 #include "bytes.h"
 
 /*
- * BLS12-381-specifc Fr shortcuts to assembly.
+ * BLS12-381-specific Fr shortcuts to assembly.
  */
 void blst_fr_add(vec256 ret, const vec256 a, const vec256 b)
 {   add_mod_256(ret, a, b, BLS12_381_r);   }
@@ -150,7 +150,7 @@ void blst_sk_inverse(pow256 ret, const pow256 a)
 }
 
 /*
- * BLS12-381-specifc Fp shortcuts to assembly.
+ * BLS12-381-specific Fp shortcuts to assembly.
  */
 void blst_fp_add(vec384 ret, const vec384 a, const vec384 b)
 {   add_fp(ret, a, b);   }
@@ -284,7 +284,7 @@ void blst_lendian_from_fp(unsigned char ret[48], const vec384 a)
 }
 
 /*
- * BLS12-381-specifc Fp2 shortcuts to assembly.
+ * BLS12-381-specific Fp2 shortcuts to assembly.
  */
 void blst_fp2_add(vec384x ret, const vec384x a, const vec384x b)
 {   add_fp2(ret, a, b);   }
@@ -311,7 +311,7 @@ void blst_fp2_cneg(vec384x ret, const vec384x a, int flag)
 {   cneg_fp2(ret, a, is_zero(flag) ^ 1);   }
 
 /*
- * Scalar serialization/deseriazation
+ * Scalar serialization/deseriazation.
  */
 void blst_scalar_from_uint32(pow256 ret, const unsigned int a[8])
 {
@@ -541,7 +541,7 @@ int blst_scalar_from_be_bytes(pow256 out, const unsigned char *bytes, size_t n)
 }
 
 /*
- * Test facilitator
+ * Test facilitator.
  */
 void blst_scalar_from_hexascii(pow256 ret, const char *hex)
 {   bytes_from_hexascii(ret, sizeof(pow256), hex);   }

--- a/src/fields.h
+++ b/src/fields.h
@@ -10,7 +10,7 @@
 #include "consts.h"
 
 /*
- * BLS12-381-specifc Fp shortcuts to assembly.
+ * BLS12-381-specific Fp shortcuts to assembly.
  */
 static inline void add_fp(vec384 ret, const vec384 a, const vec384 b)
 {   add_mod_384(ret, a, b, BLS12_381_P);   }
@@ -49,7 +49,7 @@ static inline void redc_fp(vec384 ret, const vec768 a)
 {   redc_mont_384(ret, a, BLS12_381_P, p0);   }
 
 /*
- * BLS12-381-specifc Fp2 shortcuts to assembly.
+ * BLS12-381-specific Fp2 shortcuts to assembly.
  */
 static inline void add_fp2(vec384x ret, const vec384x a, const vec384x b)
 {   add_mod_384x(ret, a, b, BLS12_381_P);   }

--- a/src/fp12_tower.c
+++ b/src/fp12_tower.c
@@ -545,7 +545,7 @@ static void inverse_fp6(vec384fp6 ret, const vec384fp6 a)
     mul_by_u_plus_1_fp2(c1, c1);
     mul_fp2(t0, a[0], a[1]);
     sub_fp2(c1, c1, t0);
- 
+
     /* c2 = a1^2 - a0*a2 */
     sqr_fp2(c2, a[1]);
     mul_fp2(t0, a[0], a[2]);
@@ -733,7 +733,7 @@ static void frobenius_map_fp12(vec384fp12 ret, const vec384fp12 a, size_t n)
 
 
 /*
- * BLS12-381-specifc Fp12 shortcuts.
+ * BLS12-381-specific Fp12 shortcuts.
  */
 void blst_fp12_sqr(vec384fp12 ret, const vec384fp12 a)
 {   sqr_fp12(ret, a);   }


### PR DESCRIPTION
This PR fixes a minor typo in some of the comments.
* "specifc" -> "specific"

Also, add punctuation to a couple of docstring comments for consistency.