### PR TITLE
Expose SHA-256 functions

### DIFF
--- a/bindings/blst_aux.h
+++ b/bindings/blst_aux.h
@@ -99,4 +99,19 @@ size_t blst_p1_affine_sizeof();
 size_t blst_p2_sizeof();
 size_t blst_p2_affine_sizeof();
 size_t blst_fp12_sizeof();
+
+typedef struct {
+    unsigned int h[8];
+    unsigned long long N;
+    unsigned char buf[64];
+    size_t off;
+} BLST_SHA256_CTX;
+
+/*
+ * SHA-256 functions.
+ */
+void blst_sha256_init(BLST_SHA256_CTX *ctx);
+void blst_sha256_update(BLST_SHA256_CTX *ctx, const void *inp, size_t len);
+void blst_sha256_final(unsigned char md[32], BLST_SHA256_CTX *ctx);
+
 #endif

--- a/bindings/blst_aux.h
+++ b/bindings/blst_aux.h
@@ -101,17 +101,8 @@ size_t blst_p2_affine_sizeof();
 size_t blst_fp12_sizeof();
 
 /*
- * SHA-256 functions.
+ * SHA-256 hash function.
  */
-typedef struct {
-    unsigned int h[8];
-    unsigned long long N;
-    unsigned char buf[64];
-    size_t off;
-} BLST_SHA256_CTX;
-
-void blst_sha256_init(BLST_SHA256_CTX *ctx);
-void blst_sha256_update(BLST_SHA256_CTX *ctx, const void *inp, size_t len);
-void blst_sha256_final(unsigned char md[32], BLST_SHA256_CTX *ctx);
+void blst_sha256(unsigned char md[32], const void *msg, size_t len);
 
 #endif

--- a/bindings/blst_aux.h
+++ b/bindings/blst_aux.h
@@ -100,6 +100,9 @@ size_t blst_p2_sizeof();
 size_t blst_p2_affine_sizeof();
 size_t blst_fp12_sizeof();
 
+/*
+ * SHA-256 functions.
+ */
 typedef struct {
     unsigned int h[8];
     unsigned long long N;
@@ -107,9 +110,6 @@ typedef struct {
     size_t off;
 } BLST_SHA256_CTX;
 
-/*
- * SHA-256 functions.
- */
 void blst_sha256_init(BLST_SHA256_CTX *ctx);
 void blst_sha256_update(BLST_SHA256_CTX *ctx, const void *inp, size_t len);
 void blst_sha256_final(unsigned char md[32], BLST_SHA256_CTX *ctx);

--- a/src/exports.c
+++ b/src/exports.c
@@ -542,16 +542,16 @@ int blst_scalar_from_be_bytes(pow256 out, const unsigned char *bytes, size_t n)
 }
 
 /*
- * SHA-256 functions.
+ * SHA-256 hash function.
  */
-void blst_sha256_init(SHA256_CTX *ctx)
-{   sha256_init(ctx);   }
+void blst_sha256(unsigned char md[32], const void *msg, size_t len)
+{
+    SHA256_CTX ctx;
 
-void blst_sha256_update(SHA256_CTX *ctx, const void *inp, size_t len)
-{   sha256_update(ctx, inp, len);   }
-
-void blst_sha256_final(unsigned char md[32], SHA256_CTX *ctx)
-{   sha256_final(md, ctx);   }
+    sha256_init(&ctx);
+    sha256_update(&ctx, msg, len);
+    sha256_final(md, &ctx);
+}
 
 /*
  * Test facilitator

--- a/src/exports.c
+++ b/src/exports.c
@@ -17,6 +17,7 @@
 
 #include "fields.h"
 #include "bytes.h"
+#include "sha256.h"
 
 /*
  * BLS12-381-specifc Fr shortcuts to assembly.
@@ -539,6 +540,18 @@ int blst_scalar_from_be_bytes(pow256 out, const unsigned char *bytes, size_t n)
 
     return (int)(ret^1);
 }
+
+/*
+ * SHA-256 functions.
+ */
+void blst_sha256_init(SHA256_CTX *ctx)
+{   sha256_init(ctx);   }
+
+void blst_sha256_update(SHA256_CTX *ctx, const void *inp, size_t len)
+{   sha256_update(ctx, inp, len);   }
+
+void blst_sha256_final(unsigned char md[32], SHA256_CTX *ctx)
+{   sha256_final(md, ctx);   }
 
 /*
  * Test facilitator


### PR DESCRIPTION
This PR exposes the blst sha256 functions in the auxiliary header. This is for [c-kzg-4844](https://github.com/ethereum/c-kzg-4844) which currently [patches blst](https://github.com/ethereum/c-kzg-4844/blob/main/blst_sha.patch) to expose these functions. It would beneficial to us if these functions were exported. This PR only makes these functions available from C and not any of the other bindings. This is all we want/need at the moment.