### PR TITLE
node: Added c++20 compiler for node19

### DIFF
--- a/bindings/node.js/run.me
+++ b/bindings/node.js/run.me
@@ -36,7 +36,7 @@ if [ ! -f blst.node -o blst_wrap.cpp -nt blst.node \
                     -o ../libblst.a  -nt blst.node ]; then
     # figure out minimally required C++ standard and enforce it...
     if [ `$NODE -e 'console.log(parseInt(process.versions["node"]))'` -gt 14 ]; then
-        min=14
+        min=20
     else
         min=11
     fi


### PR DESCRIPTION
Following the conversation https://github.com/swig/swig/issues/2506 I had initially thought this was a SWIG code generation but it just turns out the bash script was not utilizing the correct toolchain in order to support Node 19