### PR TITLE
add serde support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         cargo test --release
         cargo test --release --features=no-threads
         cargo test --release --features=serde
+        cargo test --release --features=serde-secret
         if [ `uname -s` = "Linux" ]; then
             rustup target add wasm32-wasi
             curl https://wasmtime.dev/install.sh -sSf | bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         fi
         cargo test --release
         cargo test --release --features=no-threads
+        cargo test --release --features=serde
         if [ `uname -s` = "Linux" ]; then
             rustup target add wasm32-wasi
             curl https://wasmtime.dev/install.sh -sSf | bash

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -36,6 +36,8 @@ force-adx = []
 # Suppress multi-threading.
 # Engaged on wasm32 target architecture automatically.
 no-threads = []
+# Support serialization and deserialization using serde
+serde = ["serde_actual", "serde_bytes"]
 
 [build-dependencies]
 cc = "1.0"
@@ -44,6 +46,8 @@ glob = "0.3"
 
 [dependencies]
 zeroize = { version = "^1.1", features = ["zeroize_derive"] }
+serde_actual = { package = "serde", version = "1.0.152", optional = true }
+serde_bytes= { version = "0.11.9", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 threadpool = "^1.8.1"
@@ -51,6 +55,7 @@ threadpool = "^1.8.1"
 [dev-dependencies]
 rand = "0.7"
 rand_chacha = "0.2"
+rmp-serde = "1.1.1"
 criterion = "0.3"
 
 [[bench]]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -36,10 +36,6 @@ force-adx = []
 # Suppress multi-threading.
 # Engaged on wasm32 target architecture automatically.
 no-threads = []
-# Support serialization and deserialization using serde
-serde = ["serde_actual", "serde_bytes"]
-# Use compressed point representations when serializing.
-serde_compressed = ["serde"]
 
 [build-dependencies]
 cc = "1.0"
@@ -48,8 +44,7 @@ glob = "0.3"
 
 [dependencies]
 zeroize = { version = "^1.1", features = ["zeroize_derive"] }
-serde_actual = { package = "serde", version = "1.0.152", optional = true }
-serde_bytes= { version = "0.11.9", optional = true }
+serde = { version = "1.0.152", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 threadpool = "^1.8.1"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -36,6 +36,8 @@ force-adx = []
 # Suppress multi-threading.
 # Engaged on wasm32 target architecture automatically.
 no-threads = []
+# Add support for serializing secrets
+serde-secret = ["serde"]
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -38,6 +38,8 @@ force-adx = []
 no-threads = []
 # Support serialization and deserialization using serde
 serde = ["serde_actual", "serde_bytes"]
+# Use compressed point representations when serializing.
+serde_compressed = ["serde"]
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -673,7 +673,7 @@ macro_rules! sig_variant_impl {
                 &self,
                 ser: S,
             ) -> Result<S::Ok, S::Error> {
-                serde_bytes::ByteBuf::from(self.to_bytes()).serialize(ser)
+                serde_bytes::ByteBuf::from(self.serialize()).serialize(ser)
             }
         }
 
@@ -796,11 +796,20 @@ macro_rules! sig_variant_impl {
 
         #[cfg(feature = "serde")]
         impl Serialize for PublicKey {
+            #[cfg(not(feature = "serde_compressed"))]
             fn serialize<S: Serializer>(
                 &self,
                 ser: S,
             ) -> Result<S::Ok, S::Error> {
-                serde_bytes::ByteBuf::from(self.to_bytes()).serialize(ser)
+                serde_bytes::ByteBuf::from(self.serialize()).serialize(ser)
+            }
+
+            #[cfg(feature = "serde_compressed")]
+            fn serialize<S: Serializer>(
+                &self,
+                ser: S,
+            ) -> Result<S::Ok, S::Error> {
+                serde_bytes::ByteBuf::from(self.compress()).serialize(ser)
             }
         }
 
@@ -1246,11 +1255,20 @@ macro_rules! sig_variant_impl {
 
         #[cfg(feature = "serde")]
         impl Serialize for Signature {
+            #[cfg(not(feature = "serde_compressed"))]
             fn serialize<S: Serializer>(
                 &self,
                 ser: S,
             ) -> Result<S::Ok, S::Error> {
-                serde_bytes::ByteBuf::from(self.to_bytes()).serialize(ser)
+                serde_bytes::ByteBuf::from(self.serialize()).serialize(ser)
+            }
+
+            #[cfg(feature = "serde_compressed")]
+            fn serialize<S: Serializer>(
+                &self,
+                ser: S,
+            ) -> Result<S::Ok, S::Error> {
+                serde_bytes::ByteBuf::from(self.compress()).serialize(ser)
             }
         }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -15,7 +15,7 @@ use core::sync::atomic::*;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::sync::{mpsc::channel, Arc, Barrier};
 use zeroize::Zeroize;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-secret")]
 use zeroize::Zeroizing;
 
 trait ThreadPoolExt {
@@ -669,7 +669,7 @@ macro_rules! sig_variant_impl {
             }
         }
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "serde-secret")]
         impl Serialize for SecretKey {
             fn serialize<S: Serializer>(
                 &self,
@@ -680,7 +680,7 @@ macro_rules! sig_variant_impl {
             }
         }
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "serde-secret")]
         impl<'de> Deserialize<'de> for SecretKey {
             fn deserialize<D: Deserializer<'de>>(
                 deser: D,
@@ -1704,6 +1704,45 @@ macro_rules! sig_variant_impl {
             #[cfg(feature = "serde")]
             #[test]
             fn test_serde() {
+                let seed = [0u8; 32];
+                let mut rng = ChaCha20Rng::from_seed(seed);
+
+                // generate a sk, pk, and sig, and make sure it signs
+                let sk = gen_random_key(&mut rng);
+                let pk = sk.sk_to_pk();
+                let sig = sk.sign(b"asdf", b"qwer", b"zxcv");
+                assert_eq!(
+                    sig.verify(true, b"asdf", b"qwer", b"zxcv", &pk, true),
+                    BLST_ERROR::BLST_SUCCESS
+                );
+
+                // roundtrip through serde
+                let pk_ser =
+                    rmp_serde::encode::to_vec_named(&pk).expect("ser pk");
+                let sig_ser =
+                    rmp_serde::encode::to_vec_named(&sig).expect("ser sig");
+                let pk_des: PublicKey =
+                    rmp_serde::decode::from_slice(&pk_ser).expect("des pk");
+                let sig_des: Signature =
+                    rmp_serde::decode::from_slice(&sig_ser).expect("des sig");
+
+                // check that we got back the right things
+                assert_eq!(pk, pk_des);
+                assert_eq!(sig, sig_des);
+                assert_eq!(
+                    sig.verify(true, b"asdf", b"qwer", b"zxcv", &pk_des, true),
+                    BLST_ERROR::BLST_SUCCESS
+                );
+                assert_eq!(
+                    sig_des.verify(true, b"asdf", b"qwer", b"zxcv", &pk, true),
+                    BLST_ERROR::BLST_SUCCESS
+                );
+                assert_eq!(sk.sign(b"asdf", b"qwer", b"zxcv"), sig_des);
+            }
+
+            #[cfg(feature = "serde-secret")]
+            #[test]
+            fn test_serde_secret() {
                 let seed = [0u8; 32];
                 let mut rng = ChaCha20Rng::from_seed(seed);
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -686,7 +686,7 @@ macro_rules! sig_variant_impl {
                 deser: D,
             ) -> Result<Self, D::Error> {
                 let bytes: &[u8] = Deserialize::deserialize(deser)?;
-                Self::deserialize(&bytes).map_err(|e| {
+                Self::deserialize(bytes).map_err(|e| {
                     <D::Error as serde::de::Error>::custom(format!("{:?}", e))
                 })
             }


### PR DESCRIPTION
This PR adds serde support for `PublicKey`, `SecretKey`, and `Signature` values for both `min_pk` and `min_sig`. It also adds a simple roundtrip test.

This support is gated by the `serde` feature flag as requested in discussion of #148. With the `serde` flag, public keys and signatures are serialized in uncompressed form.

~I also added a `serde_compressed` flag that works the same way, but it serializes compressed points instead. Since the `deserialize()` methods on `PublicKey` and `Signature` can accept both compressed and uncompressed points, there's no interoperability issues with having both compressed and uncompressed serialization. (As you can see, the deserialize function is the same in both cases!)~

If it would make sense to add some documentation for these features, please let me know. I'm not quite sure where it should be added, so a pointer would be appreciated!

---

closes #148