### PR TITLE
Add field to blst_uniq to fix compiler error with msvc

### DIFF
--- a/bindings/blst_aux.h
+++ b/bindings/blst_aux.h
@@ -50,7 +50,8 @@ void blst_sk_to_pk2_in_g2(byte out[192], blst_p2_affine *out_pk,
 void blst_sign_pk2_in_g2(byte out[96], blst_p1_affine *out_sig,
                          const blst_p1 *hash, const blst_scalar *SK);
 
-typedef struct {} blst_uniq;
+/* The _unused field is there to fix a compiler error */
+typedef struct { char _unused; } blst_uniq;
 
 size_t blst_uniq_sizeof(size_t n_nodes);
 void blst_uniq_init(blst_uniq *tree);


### PR DESCRIPTION
When compiling with MSVC on Windows, we get the following error:

```
blst\bindings\blst_aux.h(53): error C2016: C requires that a struct or union have at least one member
```

Currently, to solve this issue, we are patching this file before compilation. It would be nice to not do that.

Not sure if the comment and field name are to your liking. Feel free to suggest something else.