### PR TITLE
Add blst_fp deserialization `blst_fp12_from_bendian`

### DIFF
--- a/bindings/blst.hpp
+++ b/bindings/blst.hpp
@@ -860,6 +860,10 @@ public:
     bool in_group() const   { return blst_fp12_in_group(&value); }
     void to_bendian(byte out[48*12]) const
     {   blst_bendian_from_fp12(out, &value);   }
+    void from_bendian(const byte in[48 * 12]) const
+    {
+        blst_fp12_from_bendian(&value, in);
+    }
 
     static bool finalverify(const PT& gt1, const PT& gt2)
     {   return blst_fp12_finalverify(gt1, gt2);   }

--- a/bindings/blst_aux.h
+++ b/bindings/blst_aux.h
@@ -86,6 +86,7 @@ void blst_pairing_raw_aggregate(blst_pairing *ctx, const blst_p2_affine *q,
                                                    const blst_p1_affine *p);
 blst_fp12 *blst_pairing_as_fp12(blst_pairing *ctx);
 void blst_bendian_from_fp12(byte out[48*12], const blst_fp12 *a);
+void blst_fp12_from_bendian(blst_fp12 *out, const byte in[48 * 12]);
 
 void blst_keygen_v3(blst_scalar *out_SK, const byte *IKM, size_t IKM_len,
                     const byte *info DEFNULL, size_t info_len DEFNULL);

--- a/src/fp12_tower.c
+++ b/src/fp12_tower.c
@@ -785,5 +785,26 @@ void blst_bendian_from_fp12(unsigned char ret[48*12], const vec384fp12 a)
     }
 }
 
+void blst_fp12_from_bendian(vec384fp12 out, const byte in[48 * 12])
+{
+    size_t i, j;
+    const byte *in_ptr = in;
+    vec384 tmp_vec;
+
+    for (i = 0; i < 3; i++)
+    {
+        for (j = 0; j < 2; j++)
+        {
+            limbs_from_be_bytes(tmp_vec, in_ptr, sizeof(vec384));
+            mul_fp(out[j][i][0], tmp_vec, BLS12_381_RR);
+            in_ptr += 48;
+
+            limbs_from_be_bytes(tmp_vec, in_ptr, sizeof(vec384));
+            mul_fp(out[j][i][1], tmp_vec, BLS12_381_RR);
+            in_ptr += 48;
+        }
+    }
+}
+
 size_t blst_fp12_sizeof(void)
 {   return sizeof(vec384fp12);   }


### PR DESCRIPTION
blst_fp12 has a serialization function `blst_bendian_from_fp12` - but was missing the corresponding deserialization function.

This PR adds `blst_fp12_from_bendian` for this purpose.