### PR TITLE
ec_mult.h: add minimal countermeasure against power-monitoring attack.

### DIFF
--- a/src/vect.h
+++ b/src/vect.h
@@ -381,6 +381,21 @@ static inline void vec_zero(void *ret, size_t num)
 #endif
 }
 
+static inline void vec_czero(void *ret, size_t num, bool_t cbit)
+{
+    limb_t *rp = (limb_t *)ret;
+    size_t i;
+    limb_t mask;
+
+    launder(cbit);
+    mask = (limb_t)0 - (cbit^1);
+
+    num /= sizeof(limb_t);
+
+    for (i = 0; i < num; i++)
+        rp[i] &= mask;
+}
+
 /*
  * Some compilers get arguably overzealous(*) when passing pointer to
  * multi-dimensional array [such as vec384x] as 'const' argument.


### PR DESCRIPTION
It's argued that [batches of] multiplications by zero can be discerned by monitoring the power and possibly even electromagnetic radiation. Since [otherwise constant-time] operations on infinity points perform batches of multiplications by zero, they could be used to identify sequences of zero bits in the secret key. To minimize the leakage, always pass non-infinity points to point operations and mask the throw-away results.
