### PR TITLE
feat(bindings/rust): add constructor for affine points

### DIFF
--- a/bindings/rust/src/pippenger-no_std.rs
+++ b/bindings/rust/src/pippenger-no_std.rs
@@ -46,6 +46,10 @@ macro_rules! pippenger_mult_impl {
                 self.points.as_slice()
             }
 
+            pub fn new(points: &[$point_affine]) -> Self {
+                Self { points: Vec::from(points) }
+            }
+
             pub fn from(points: &[$point]) -> Self {
                 let npoints = points.len();
                 let mut ret = Self {

--- a/bindings/rust/src/pippenger.rs
+++ b/bindings/rust/src/pippenger.rs
@@ -69,6 +69,10 @@ macro_rules! pippenger_mult_impl {
                 self.points.as_slice()
             }
 
+            pub fn new(points: &[$point_affine]) -> Self {
+                Self { points: Vec::from(points) }
+            }
+
             pub fn from(points: &[$point]) -> Self {
                 let npoints = points.len();
                 let mut ret = Self {


### PR DESCRIPTION
in the `rust` bindings, add a constructor for affine points (i.e. `p1_affines` and `p2_affines`) whose argument is a slice of affine points.