### PR TITLE
C# - look for native library in nuget conventional locations

### DIFF
--- a/bindings/c#/run.me
+++ b/bindings/c#/run.me
@@ -32,6 +32,10 @@ static blst()
 {
     if (String.IsNullOrEmpty(dll))
     {
+        var name = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "blst.dll"
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libblst.dll.dylib"
+                    : "libblst.dll.so";
+
         var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".";
         var arch = RuntimeInformation.ProcessArchitecture switch
         {
@@ -39,21 +43,18 @@ static blst()
             Architecture.Arm64 => "arm64",
             _ => "unsupported"
         };
-        var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win"
-                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx"
-                    : RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) ? "freebsd"
-                    : "linux";
-        var name = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "blst.dll"
-                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libblst.dll.dylib"
-                    : "libblst.dll.so";
 
 #if NET8_0_OR_GREATER
-        // RuntimeInformation.RuntimeIdentifier changed between net 7 and 8 
+        // RuntimeInformation.RuntimeIdentifier changed between net 7 and 8
         // and only aligns to the nuget layout in 8+
         var rid = RuntimeInformation.RuntimeIdentifier;
 #else
         // mimic RuntimeInformation.RuntimeIdentifier on  earlier than .NET 8
-        // mimic "win-x64", "linux-x64", "linux-arm64", "osx-x64" 
+        // mimic "win-x64", "linux-x64", "linux-arm64", "osx-x64"
+        var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win"
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx"
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) ? "freebsd"
+                    : "linux";
         var rid = $"{os}-{arch}";
 #endif
 
@@ -64,12 +65,12 @@ static blst()
         {
             // if not found in the nuget location, try a simple default
             dll = Path.Combine(dir, arch, name);
+        }
 
-            if (!File.Exists(dll))
-            {
-                // if not there we'll try the current directory
-                dll = Path.Combine(Environment.CurrentDirectory, name);
-            }
+        if (!File.Exists(dll))
+        {
+            // if not there we'll try the current directory
+            dll = Path.Combine(Environment.CurrentDirectory, name);
         }
 
         if (File.Exists(dll))

--- a/bindings/c#/supranational.blst.cs
+++ b/bindings/c#/supranational.blst.cs
@@ -28,6 +28,10 @@ static blst()
 {
     if (String.IsNullOrEmpty(dll))
     {
+        var name = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "blst.dll"
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libblst.dll.dylib"
+                    : "libblst.dll.so";
+
         var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".";
         var arch = RuntimeInformation.ProcessArchitecture switch
         {
@@ -35,21 +39,18 @@ static blst()
             Architecture.Arm64 => "arm64",
             _ => "unsupported"
         };
-        var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win"
-                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx"
-                    : RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) ? "freebsd"
-                    : "linux";
-        var name = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "blst.dll"
-                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libblst.dll.dylib"
-                    : "libblst.dll.so";
 
 #if NET8_0_OR_GREATER
-        // RuntimeInformation.RuntimeIdentifier changed between net 7 and 8 
+        // RuntimeInformation.RuntimeIdentifier changed between net 7 and 8
         // and only aligns to the nuget layout in 8+
         var rid = RuntimeInformation.RuntimeIdentifier;
 #else
         // mimic RuntimeInformation.RuntimeIdentifier on  earlier than .NET 8
-        // mimic "win-x64", "linux-x64", "linux-arm64", "osx-x64" 
+        // mimic "win-x64", "linux-x64", "linux-arm64", "osx-x64"
+        var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win"
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx"
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) ? "freebsd"
+                    : "linux";
         var rid = $"{os}-{arch}";
 #endif
 
@@ -60,12 +61,12 @@ static blst()
         {
             // if not found in the nuget location, try a simple default
             dll = Path.Combine(dir, arch, name);
+        }
 
-            if (!File.Exists(dll))
-            {
-                // if not there we'll try the current directory
-                dll = Path.Combine(Environment.CurrentDirectory, name);
-            }
+        if (!File.Exists(dll))
+        {
+            // if not there we'll try the current directory
+            dll = Path.Combine(Environment.CurrentDirectory, name);
         }
 
         if (File.Exists(dll))


### PR DESCRIPTION
.NET's package manage, [NuGet](https://www.nuget.org/), will [install native libraries in a standard location](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages#putting-it-together), denoted by it's [Runtime Identifier](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog). This is the most common way for a .net package to be deployed.

This change modifies the C# POC code to look in those locations when loading the native library in the `blst` static constructor, making it easier to author NuGet packages that include the blst native libraries.

