### PR TITLE
Fix/ctq inverse mod 384

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -2060,3 +2060,19 @@ mod sk_test {
         assert_eq!(p2, unsafe { *blst_p2_generator() });
     }
 }
+
+#[cfg(test)]
+mod fp_test {
+    use super::*;
+    #[test]
+    fn inverse() {
+        let mut out = blst_fp::default();
+        let inp = blst_fp::default();
+
+        unsafe {
+            blst_fp_inverse(&mut out, &inp);
+        }
+    }
+
+    assert_eq!(out, blst_fp { l: [0,0,0,0,0,0] });
+}

--- a/build/coff/ctq_inverse_mod_384-x86_64.s
+++ b/build/coff/ctq_inverse_mod_384-x86_64.s
@@ -1226,9 +1226,9 @@ __inner_loop_62:
 	movq	8(%rsp),%rsi
 	
 #ifdef	__SGX_LVI_HARDENING__
-	popq	%r8
+	popq	%rdx
 	lfence
-	jmpq	*%r8
+	jmpq	*%rdx
 	ud2
 #else
 	.byte	0xf3,0xc3

--- a/build/elf/ctq_inverse_mod_384-x86_64.s
+++ b/build/elf/ctq_inverse_mod_384-x86_64.s
@@ -1230,9 +1230,9 @@ __inner_loop_62:
 	movq	8(%rsp),%rsi
 	
 #ifdef	__SGX_LVI_HARDENING__
-	popq	%r8
+	popq	%rdx
 	lfence
-	jmpq	*%r8
+	jmpq	*%rdx
 	ud2
 #else
 	.byte	0xf3,0xc3

--- a/build/mach-o/ctq_inverse_mod_384-x86_64.s
+++ b/build/mach-o/ctq_inverse_mod_384-x86_64.s
@@ -1230,9 +1230,9 @@ L$oop_62:
 	movq	8(%rsp),%rsi
 	
 #ifdef	__SGX_LVI_HARDENING__
-	popq	%r8
+	popq	%rdx
 	lfence
-	jmpq	*%r8
+	jmpq	*%rdx
 	ud2
 #else
 	.byte	0xf3,0xc3

--- a/build/win64/ctq_inverse_mod_384-x86_64.asm
+++ b/build/win64/ctq_inverse_mod_384-x86_64.asm
@@ -1231,9 +1231,9 @@ $L$oop_62::
 	mov	rsi,QWORD PTR[8+rsp]
 	
 ifdef	__SGX_LVI_HARDENING__
-	pop	r8
+	pop	rdx
 	lfence
-	jmp	r8
+	jmp	rdx
 	ud2
 else
 	DB	0F3h,0C3h

--- a/src/asm/ctq_inverse_mod_384-x86_64.pl
+++ b/src/asm/ctq_inverse_mod_384-x86_64.pl
@@ -887,7 +887,7 @@ __inner_loop_62:
 	jnz	.Loop_62
 
 	mov	8(%rsp), $in_ptr
-	ret	# __SGX_LVI_HARDENING_CLOBBER__=$a_lo
+	ret	# __SGX_LVI_HARDENING_CLOBBER__=$cnt
 .size	__inner_loop_62,.-__inner_loop_62
 ___
 }


### PR DESCRIPTION
This PR fixes Issue #214 by using $rdx rather than $r8 as the scratch register.
The perl file is updated to clobber $cnt and all asm files are refreshed.
