### PR TITLE
Add feature flag "sgx"

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -38,6 +38,8 @@ force-adx = []
 no-threads = []
 # Add support for serializing SecretKey, not suitable for production.
 serde-secret = ["serde"]
+# Add sgx flag to enable non-fortanix SGX support
+sgx = []
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -222,7 +222,7 @@ fn main() {
         }
         cc.define("SCRATCH_LIMIT", "(45 * 1024)");
     }
-    if target_env.eq("sgx") {
+    if target_env.eq("sgx") || cfg!(feature = "sgx") {
         cc.flag_if_supported("-mlvi-hardening");
         cc.flag("-ffreestanding");
         cc.define("__SGX_LVI_HARDENING__", None);


### PR DESCRIPTION
Adds a new feature flag is to enable support for non-fortanix Intel SGX environments.

Also makes it easier to test SGX specific modifications to the code.
For example in issue #214 , the test can be executed on the SGX variant by just using
`cargo test --features "sgx portable" fp_test`