### PR TITLE
Fix failure of golang on loongarch64

### DIFF
--- a/bindings/go/blst.go
+++ b/bindings/go/blst.go
@@ -12,7 +12,7 @@ package blst
 
 // #cgo CFLAGS: -I${SRCDIR}/.. -I${SRCDIR}/../../build -I${SRCDIR}/../../src -D__BLST_CGO__ -fno-builtin-memcpy -fno-builtin-memset
 // #cgo amd64 CFLAGS: -D__ADX__ -mno-avx
-// #cgo mips64 mips64le ppc64 ppc64le riscv64 s390x CFLAGS: -D__BLST_NO_ASM__
+// #cgo mips64 mips64le ppc64 ppc64le riscv64 s390x loong64 CFLAGS: -D__BLST_NO_ASM__
 // #include "blst.h"
 //
 // #if defined(__x86_64__) && (defined(__unix__) || defined(__APPLE__))

--- a/bindings/go/blst.tgo
+++ b/bindings/go/blst.tgo
@@ -8,7 +8,7 @@ package blst
 
 // #cgo CFLAGS: -I${SRCDIR}/.. -I${SRCDIR}/../../build -I${SRCDIR}/../../src -D__BLST_CGO__ -fno-builtin-memcpy -fno-builtin-memset
 // #cgo amd64 CFLAGS: -D__ADX__ -mno-avx
-// #cgo mips64 mips64le ppc64 ppc64le riscv64 s390x CFLAGS: -D__BLST_NO_ASM__
+// #cgo mips64 mips64le ppc64 ppc64le riscv64 s390x loong64 CFLAGS: -D__BLST_NO_ASM__
 // #include "blst.h"
 //
 // #if defined(__x86_64__) && (defined(__unix__) || defined(__APPLE__))


### PR DESCRIPTION
Golang supports loognarch64 since [1.19](https://tip.golang.org/doc/go1.19#loong64).