### PR TITLE
Add swig bindings for field element mapping to G1 and G2

### DIFF
--- a/bindings/blst.h
+++ b/bindings/blst.h
@@ -273,10 +273,10 @@ void blst_p2s_tile_pippenger(blst_p2 *ret, const blst_p2_affine *const points[],
 /*
  * Hash-to-curve operations.
  */
-#ifndef SWIG
+
 void blst_map_to_g1(blst_p1 *out, const blst_fp *u, const blst_fp *v DEFNULL);
+
 void blst_map_to_g2(blst_p2 *out, const blst_fp2 *u, const blst_fp2 *v DEFNULL);
-#endif
 
 void blst_encode_to_g1(blst_p1 *out,
                        const byte *msg, size_t msg_len,

--- a/bindings/blst.hpp
+++ b/bindings/blst.hpp
@@ -307,6 +307,14 @@ public:
                                   aug, aug_len);
         return this;
     }
+    P1* map_to(const byte *u)
+    {
+        blst_fp ret;
+        blst_fp_from_bendian(&ret, u);
+        blst_map_to_g1(&point, &ret, nullptr);
+        return this;
+    }
+
 #if __cplusplus >= 201703L
     P1* hash_to(const app__string_view msg, const std::string& DST = "",
                 const app__string_view aug = None)
@@ -605,6 +613,15 @@ public:
                                   aug, aug_len);
         return this;
     }
+    P2* map_to(const byte *u)
+    {
+        blst_fp2 fp2;
+        blst_fp_from_bendian(&fp2.fp[0], u);
+        blst_fp_from_bendian(&fp2.fp[1], u+48);
+        blst_map_to_g2(&point, &fp2, nullptr);
+        return this;
+    }
+
 #if __cplusplus >= 201703L
     P2* hash_to(const app__string_view msg, const std::string& DST = "",
                 const app__string_view aug = None)

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -723,7 +723,7 @@ import java.nio.file.*;
     blst::P1* sign_with,    blst::P2* sign_with,
     blst::P1* hash_to,      blst::P2* hash_to,
     blst::P1* encode_to,    blst::P2* encode_to,
-    blst::P1* map_to_g1,    blst::P2* map_to_g2,
+    blst::P1* map_to,       blst::P2* map_to,
     blst::P1* mult,         blst::P2* mult,
     blst::P1* cneg,         blst::P2* cneg,
     blst::P1* neg,          blst::P2* neg,

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -723,6 +723,7 @@ import java.nio.file.*;
     blst::P1* sign_with,    blst::P2* sign_with,
     blst::P1* hash_to,      blst::P2* hash_to,
     blst::P1* encode_to,    blst::P2* encode_to,
+    blst::P1* map_to_g1,    blst::P2* map_to_g2,
     blst::P1* mult,         blst::P2* mult,
     blst::P1* cneg,         blst::P2* cneg,
     blst::P1* neg,          blst::P2* neg,


### PR DESCRIPTION
In trying to use [jblst](https://github.com/consensys/jblst) (and therefore blst) for [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) implementation in Hyperledger Besu's besu-native project, I found that `blst_map_to_g1` and `blst_map_to_g2` were not exposed via SWIG.

I suspect there was a reason that these functions were left out of the swig bindings, but I don't know why.  To get a complete implementation, I added them (disclaimer: not a C programmer nor familiar with SWIG).  

Using BLST java bindings is the fastest implementation we have tested, so we are motivated to use it as the basis for EIp-2537 in besu.  I did verify that java python and rust bindings still build correctly, but only tested Java bindings.

If this should go in blst_aux.h or elsewhere, or if there is another way to map field elements without adding these methods to the interface, LMK.  TIA