### PR TITLE
feat: add multiply_by to rust bindings

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -786,14 +786,18 @@ macro_rules! sig_variant_impl {
         impl PublicKey {
             // Core operations
 
-            pub fn multiply_by(&self, rand: &[u8]) -> PublicKey {
+            pub fn multiply_by(
+                &self,
+                rand: &[u8],
+                rand_bits: usize,
+            ) -> PublicKey {
                 let mut input = <$pk>::default();
                 let mut output = <$pk>::default();
                 let mut ret_val = <$pk_aff>::default();
                 unsafe {
                     $pk_from_aff(&mut input, &self.point);
                     // convert byte length to bit length
-                    $pk_mult(&mut output, &input, rand.as_ptr(), rand.len() * 8);
+                    $pk_mult(&mut output, &input, rand.as_ptr(), rand_bits);
                     $pk_to_aff(&mut ret_val, &output);
                 }
                 PublicKey { point: ret_val }
@@ -1016,7 +1020,7 @@ macro_rules! sig_variant_impl {
             }
         }
 
-        #[derive(Default, Debug, Clone, Copy)]
+        #[derive(Debug, Clone, Copy)]
         pub struct Signature {
             point: $sig_aff,
         }
@@ -1370,14 +1374,18 @@ macro_rules! sig_variant_impl {
                 unsafe { $sig_in_group(&self.point) }
             }
 
-            pub fn multiply_by(&self, rand: &[u8]) -> Signature {
+            pub fn multiply_by(
+                &self,
+                rand: &[u8],
+                rand_bits: usize,
+            ) -> Signature {
                 let mut input = <$sig>::default();
                 let mut output = <$sig>::default();
                 let mut ret_val = <$sig_aff>::default();
                 unsafe {
                     $sig_from_aff(&mut input, &self.point);
                     // convert byte length to bit length
-                    $sig_mult(&mut output, &input, rand.as_ptr(), rand.len() * 8);
+                    $sig_mult(&mut output, &input, rand.as_ptr(), rand_bits);
                     $sig_to_aff(&mut ret_val, &output);
                 }
                 Signature { point: ret_val }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -541,8 +541,10 @@ macro_rules! sig_variant_impl {
         $sig_ser_size:expr,
         $pk_add_or_dbl:ident,
         $pk_add_or_dbl_aff:ident,
+        $pk_mult:ident,
         $sig_add_or_dbl:ident,
         $sig_add_or_dbl_aff:ident,
+        $sig_mult:ident,
         $pk_is_inf:ident,
         $sig_is_inf:ident,
         $sig_aggr_in_group:ident,
@@ -783,6 +785,18 @@ macro_rules! sig_variant_impl {
 
         impl PublicKey {
             // Core operations
+
+            pub fn multiply_by(&self, rand: &[u8]) -> PublicKey {
+                let mut input = <$pk>::default();
+                let mut output = <$pk>::default();
+                let mut ret_val = <$pk_aff>::default();
+                unsafe {
+                    $pk_from_aff(&mut input, &self.point);
+                    $pk_mult(&mut output, &input, rand.as_ptr(), 64);
+                    $pk_to_aff(&mut ret_val, &output);
+                }
+                PublicKey { point: ret_val }
+            }
 
             // key_validate
             pub fn validate(&self) -> Result<(), BLST_ERROR> {
@@ -1354,6 +1368,18 @@ macro_rules! sig_variant_impl {
             pub fn subgroup_check(&self) -> bool {
                 unsafe { $sig_in_group(&self.point) }
             }
+
+            pub fn multiply_by(&self, rand: &[u8]) -> Signature {
+                let mut input = <$sig>::default();
+                let mut output = <$sig>::default();
+                let mut ret_val = <$sig_aff>::default();
+                unsafe {
+                    $sig_from_aff(&mut input, &self.point);
+                    $sig_mult(&mut output, &input, rand.as_ptr(), 64);
+                    $sig_to_aff(&mut ret_val, &output);
+                }
+                Signature { point: ret_val }
+            }
         }
 
         // Trait for equality comparisons which are equivalence relations.
@@ -1919,8 +1945,10 @@ pub mod min_pk {
         192,
         blst_p1_add_or_double,
         blst_p1_add_or_double_affine,
+        blst_p1_mult,
         blst_p2_add_or_double,
         blst_p2_add_or_double_affine,
+        blst_p2_mult,
         blst_p1_affine_is_inf,
         blst_p2_affine_is_inf,
         blst_p2_in_g2,
@@ -1963,8 +1991,10 @@ pub mod min_sig {
         96,
         blst_p2_add_or_double,
         blst_p2_add_or_double_affine,
+        blst_p2_mult,
         blst_p1_add_or_double,
         blst_p1_add_or_double_affine,
+        blst_p1_mult,
         blst_p2_affine_is_inf,
         blst_p1_affine_is_inf,
         blst_p1_in_g1,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -792,7 +792,8 @@ macro_rules! sig_variant_impl {
                 let mut ret_val = <$pk_aff>::default();
                 unsafe {
                     $pk_from_aff(&mut input, &self.point);
-                    $pk_mult(&mut output, &input, rand.as_ptr(), 64);
+                    // convert byte length to bit length
+                    $pk_mult(&mut output, &input, rand.as_ptr(), rand.len() * 8);
                     $pk_to_aff(&mut ret_val, &output);
                 }
                 PublicKey { point: ret_val }
@@ -1375,7 +1376,8 @@ macro_rules! sig_variant_impl {
                 let mut ret_val = <$sig_aff>::default();
                 unsafe {
                     $sig_from_aff(&mut input, &self.point);
-                    $sig_mult(&mut output, &input, rand.as_ptr(), 64);
+                    // convert byte length to bit length
+                    $sig_mult(&mut output, &input, rand.as_ptr(), rand.len() * 8);
                     $sig_to_aff(&mut ret_val, &output);
                 }
                 Signature { point: ret_val }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1016,7 +1016,7 @@ macro_rules! sig_variant_impl {
             }
         }
 
-        #[derive(Debug, Clone, Copy)]
+        #[derive(Default, Debug, Clone, Copy)]
         pub struct Signature {
             point: $sig_aff,
         }


### PR DESCRIPTION
### Motivation

We have an optimization that we use to improve signature verification in our Ethereum Consensus implementation and it requires multiplying in some randomness before aggregation for security reasons.  We have switched to using the rust bindings but the native `blst_p1_affine` and `blst_p2_affine` points are private.

There are two approaches we explored but decided to provide this PR to upstream our work.  We are not super excited about having to do the conversion from affine to jacobian and then back again to allow for multiplication but leave that up to you if you feel another route is better.

The other option we explored would be to make the points public on the PublicKey and Signature structs.  We are also open to this approach if you prefer going that route but understand that is not ideal either.  On the upside though, it would allow for more flexibility for other consumers to implement the various other methods exported by the base lib.

Thank you for your consideration in advance.

### Inclusions

- add `PublicKey.multiply_by`
- add `Signature.multiply_by`