### PR TITLE
bindings/rust: implement MultiPoint for [Signature] and [PublicKey]

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -776,6 +776,7 @@ macro_rules! sig_variant_impl {
             }
         }
 
+        #[repr(transparent)]
         #[derive(Default, Debug, Clone, Copy)]
         pub struct PublicKey {
             point: $pk_aff,
@@ -1001,6 +1002,7 @@ macro_rules! sig_variant_impl {
             }
         }
 
+        #[repr(transparent)]
         #[derive(Debug, Clone, Copy)]
         pub struct Signature {
             point: $sig_aff,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1959,14 +1959,12 @@ macro_rules! sig_variant_impl {
                 // create random values
                 let mut rands: Vec<u8> = Vec::with_capacity(32 * num_pks);
                 for _ in 0..num_pks {
-                    let mut vals = [0u8; 32];
                     let mut r = rng.next_u64();
                     while r == 0 {
                         // Reject zero as it is used for multiplication.
                         r = rng.next_u64();
                     }
-                    vals[0..8].copy_from_slice(&r.to_le_bytes());
-                    rands.extend_from_slice(&vals);
+                    rands.extend_from_slice(&r.to_le_bytes());
                 }
 
                 // Sanity test each current single signature


### PR DESCRIPTION
- Implement MultiPoint for slices of Signatures and PublicKeys, as suggested in this comment: https://github.com/supranational/blst/pull/225#issuecomment-2191717350
- Enforce compatible memory layout via `repr(transparent)`, see https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent