### PR TITLE
Fix PATH expansion in comment

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,6 @@
 @echo off
 SETLOCAL
-set PATH=%windir%\system32;%PATH% &:: override msys if there is one on %PATH%
+set PATH=%windir%\system32;%PATH% &:: override msys if there is one on PATH
 set TOP=%~dp0
 cl /nologo /c /O2 /Zi /Fdblst.pdb /W4 /MT /Zl %TOP%src\server.c || EXIT /B
 cl 2>&1 | find "for ARM64" > nul:


### PR DESCRIPTION
I ran into an issue building blst on Windows via a GitHub CI runner:

```
./build.bat
The input line is too long.
The syntax of the command is incorrect.
```

With your help, we discovered that `%PATH%` was being expanded twice. First in the command & again in the comment. This caused the command to be approximately 2x the length of `PATH`. If the system were configured with a large PATH, this could cause the `set PATH` command to be longer than the 8192-character limit and, as a result, fail.