### PR TITLE
Expose uncompress and hash_to functions for JVM bindings

### DIFF
--- a/bindings/blst.hpp
+++ b/bindings/blst.hpp
@@ -294,6 +294,14 @@ public:
     P1* sign_with(const Scalar& scalar)
     {   blst_sign_pk_in_g2(&point, &point, scalar); return this;   }
     P1* hash_to(const byte* msg, size_t msg_len,
+                const byte* DST,
+                size_t DST_len,
+                const byte* aug = nullptr, size_t aug_len = 0)
+    {   blst_hash_to_g1(&point, msg, msg_len, DST, DST_len,
+                                aug, aug_len);
+        return this;
+    }
+    P1* hash_to(const byte* msg, size_t msg_len,
                 const std::string& DST = "",
                 const byte* aug = nullptr, size_t aug_len = 0)
     {   blst_hash_to_g1(&point, msg, msg_len, C_bytes(DST.data()), DST.size(),
@@ -599,6 +607,13 @@ public:
     {   blst_sign_pk_in_g1(&point, &point, &sk.key); return this;   }
     P2* sign_with(const Scalar& scalar)
     {   blst_sign_pk_in_g1(&point, &point, scalar); return this;   }
+    P2* hash_to(const byte* msg, size_t msg_len,
+                const byte* DST, size_t DST_len,
+                const byte* aug = nullptr, size_t aug_len = 0)
+    {   blst_hash_to_g2(&point, msg, msg_len, DST, DST_len,
+                                aug, aug_len);
+        return this;
+    }
     P2* hash_to(const byte* msg, size_t msg_len,
                 const std::string& DST = "",
                 const byte* aug = nullptr, size_t aug_len = 0)

--- a/bindings/blst.hpp
+++ b/bindings/blst.hpp
@@ -343,6 +343,14 @@ public:
 #endif
     static P1 generator()
     {   return P1(blst_p1_generator());   }
+    static P1_Affine uncompress(const byte in[48])
+    {
+        P1_Affine ret;
+        BLST_ERROR err = blst_p1_uncompress(ret, in);
+        if (err != BLST_SUCCESS)
+            throw err;
+        return ret;
+    }
 
 private:
     friend class P1_Affine;
@@ -641,6 +649,14 @@ public:
 #endif
     static P2 generator()
     {   return P2(blst_p2_generator());   }
+    static P2_Affine uncompress(const byte in[96])
+    {
+        P2_Affine ret;
+        BLST_ERROR err = blst_p2_uncompress(ret, in);
+        if (err != BLST_SUCCESS)
+            throw err;
+        return ret;
+    }
 
 private:
     friend class P2_Affine;

--- a/bindings/blst.swg
+++ b/bindings/blst.swg
@@ -709,10 +709,12 @@ import java.nio.file.*;
 %catches(BLST_ERROR) P1(const byte* in, size_t len);
 %catches(BLST_ERROR) P1_Affine(const byte* in, size_t len);
 %catches(BLST_ERROR) aggregate(const P1_Affine& in);
+%catches(BLST_ERROR) uncompress(const byte in[48]);
 
 %catches(BLST_ERROR) P2(const byte* in, size_t len);
 %catches(BLST_ERROR) P2_Affine(const byte* in, size_t len);
 %catches(BLST_ERROR) aggregate(const P2_Affine& in);
+%catches(BLST_ERROR) uncompress(const byte in[96]);
 
 %catches(BLST_ERROR) blst::Scalar::add;
 %catches(BLST_ERROR) blst::Scalar::sub;


### PR DESCRIPTION
`uncompress` and `hash_to` are not exposed in JVM bindings. 
This PR exposes those to JVM.

These functions are useful and are used in Cardano and specificly in JVM implementation of Cardano smart contracts VM.