### PR TITLE
fix: typos in documentation files

### DIFF
--- a/src/asm/x86_64-xlate.pl
+++ b/src/asm/x86_64-xlate.pl
@@ -1928,7 +1928,7 @@ close STDOUT;
 #	...
 #	mov	-8(%rbp),%rbx
 #	mov	%rbp,%rsp
-# .cfi_def_cfa_regiser	%rsp
+# .cfi_def_cfa_register	%rsp
 #	pop	%rbp		# recognized by Windows
 # .cfi_pop	%rbp
 # .cfi_epilogue


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `cfi_def_cfa_regiser` to `cfi_def_cfa_register`

Please review the changes and let me know if any additional changes are needed.