### PR TITLE
Rust: Add conversion between raw types and safe wrappers

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -782,9 +782,9 @@ macro_rules! sig_variant_impl {
             }
         }
 
-        impl From<&SecretKey> for blst_scalar {
-            fn from(sk: &SecretKey) -> Self {
-                sk.value.clone()
+        impl<'a> From<&'a SecretKey> for &'a blst_scalar {
+            fn from(sk: &'a SecretKey) -> Self {
+                &sk.value
             }
         }
 
@@ -1497,6 +1497,12 @@ macro_rules! sig_variant_impl {
         impl From<Signature> for $sig_aff {
             fn from(sig: Signature) -> Self {
                 sig.point
+            }
+        }
+
+        impl<'a> From<&'a Signature> for &'a $sig_aff {
+            fn from(sig: &'a Signature) -> Self {
+                &sig.point
             }
         }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -788,7 +788,7 @@ macro_rules! sig_variant_impl {
             }
         }
 
-        impl std::convert::TryFrom<blst_scalar> for SecretKey {
+        impl core::convert::TryFrom<blst_scalar> for SecretKey {
             type Error = BLST_ERROR;
 
             fn try_from(value: blst_scalar) -> Result<Self, Self::Error> {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -926,6 +926,24 @@ macro_rules! sig_variant_impl {
             }
         }
 
+        impl From<PublicKey> for $pk_aff {
+            fn from(pk: PublicKey) -> Self {
+                pk.point
+            }
+        }
+
+        impl<'a> From<&'a PublicKey> for &'a $pk_aff {
+            fn from(pk: &'a PublicKey) -> Self {
+                &pk.point
+            }
+        }
+
+        impl From<$pk_aff> for PublicKey {
+            fn from(point: $pk_aff) -> Self {
+                Self { point }
+            }
+        }
+
         #[repr(transparent)]
         #[derive(Debug, Clone, Copy)]
         pub struct AggregatePublicKey {
@@ -1040,6 +1058,24 @@ macro_rules! sig_variant_impl {
                     $pk_add_or_dbl_aff(&mut self.point, &self.point, &pk.point);
                 }
                 Ok(())
+            }
+        }
+
+        impl From<AggregatePublicKey> for $pk {
+            fn from(pk: AggregatePublicKey) -> Self {
+                pk.point
+            }
+        }
+
+        impl<'a> From<&'a AggregatePublicKey> for &'a $pk {
+            fn from(pk: &'a AggregatePublicKey) -> Self {
+                &pk.point
+            }
+        }
+
+        impl From<$pk> for AggregatePublicKey {
+            fn from(point: $pk) -> Self {
+                Self { point }
             }
         }
 
@@ -1650,6 +1686,24 @@ macro_rules! sig_variant_impl {
 
             pub fn subgroup_check(&self) -> bool {
                 unsafe { $sig_aggr_in_group(&self.point) }
+            }
+        }
+
+        impl From<AggregateSignature> for $sig {
+            fn from(sig: AggregateSignature) -> Self {
+                sig.point
+            }
+        }
+
+        impl<'a> From<&'a AggregateSignature> for &'a $sig {
+            fn from(sig: &'a AggregateSignature) -> Self {
+                &sig.point
+            }
+        }
+
+        impl From<$sig> for AggregateSignature {
+            fn from(point: $sig) -> Self {
+                Self { point }
             }
         }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1494,6 +1494,18 @@ macro_rules! sig_variant_impl {
             }
         }
 
+        impl From<Signature> for $sig_aff {
+            fn from(sig: Signature) -> Self {
+                sig.point
+            }
+        }
+
+        impl From<$sig_aff> for Signature {
+            fn from(point: $sig_aff) -> Self {
+                Self { point }
+            }
+        }
+
         #[repr(transparent)]
         #[derive(Debug, Clone, Copy)]
         pub struct AggregateSignature {


### PR DESCRIPTION
This enables use cases where users want to perform some computations using the `blst_*` functions, but also use the `blst::{min_pk,min_sig}::*` types elsewhere.