### PR TITLE
docs(readme): add aggregate signature verification example

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -68,4 +68,42 @@ let err = sig.verify(true, msg, dst, &[], &pk, true);
 assert_eq!(err, blst::BLST_ERROR::BLST_SUCCESS);
 ```
 
+Another example demonstrating aggregation and verification of **multiple signatures** over **the same message**:
+```rust
+    use blst::min_sig::*;
+    use rand::{RngCore, rngs::OsRng};
+
+    let msg = b"hello blst";
+    let dst = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
+
+    let mut sigs = Vec::new();
+    let mut pks = Vec::new();
+
+    // Generate 4 keypairs, sign the same message, and collect their signatures and public keys
+    for _ in 0..4 {
+        let mut ikm = [0u8; 32];
+        OsRng.fill_bytes(&mut ikm);
+
+        // Generate a secret key from input keying material
+        let sk = SecretKey::key_gen(&ikm, &[]).expect("Failed to generate secret key");
+        let pk = sk.sk_to_pk();
+
+        // Sign the message with this key
+        let sig = sk.sign(msg, dst, &[]);
+
+        pks.push(pk);
+        sigs.push(sig);
+    }
+
+    // Aggregate all signatures
+    let sig_refs: Vec<&Signature> = sigs.iter().collect();
+    let agg_sig = AggregateSignature::aggregate(&sig_refs, false)
+        .expect("Signature aggregation failed")
+        .to_signature();
+
+    let pk_refs: Vec<&PublicKey> = pks.iter().collect();
+    let result = agg_sig.fast_aggregate_verify(true, msg, dst, &pk_refs);
+    assert_eq!(result, blst::BLST_ERROR::BLST_SUCCESS);
+```
+
 See the tests in src/lib.rs and benchmarks in benches/blst_benches.rs for further examples of usage.


### PR DESCRIPTION
Adds a usage example to the README demonstrating aggregation and verification of multiple signatures over the same message using `fast_aggregate_verify` from `min_sig`. This complements the existing single-signer example and reflects actual usage seen in benchmarks.