### PR TITLE
build.rs: only add `-mno-avx` when targeting x86_64

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -216,8 +216,10 @@ fn main() {
     if target_env.eq("msvc") && cc.get_compiler().is_like_msvc() {
         cc.flag("-Zl");
     }
-    cc.flag_if_supported("-mno-avx") // avoid costly transitions
-        .flag_if_supported("-fno-builtin")
+    if target_arch.eq("x86_64") {
+        cc.flag_if_supported("-mno-avx"); // avoid costly transitions
+    }
+    cc.flag_if_supported("-fno-builtin")
         .flag_if_supported("-Wno-unused-function")
         .flag_if_supported("-Wno-unused-command-line-argument");
     if target_arch.eq("wasm32") || target_family.is_empty() {


### PR DESCRIPTION
fixes https://github.com/supranational/blst/issues/253

`-mno-avx` is x86_64 specific and since llvm@18, it fails with `error: unsupported option`

```
$ echo 'int main(){return 0;}' |
>   /opt/homebrew/opt/llvm\@17/bin/clang -x c - -c \
>     --target=arm64-apple-macosx -mno-avx -o /dev/null
clang: warning: argument unused during compilation: '-mno-avx' [-Wunused-command-line-argument]

$ echo 'int main(){return 0;}' |
  /opt/homebrew/opt/llvm\@18/bin/clang -x c - -c \
    --target=arm64-apple-macosx -mno-avx -o /dev/null
clang: error: unsupported option '-mno-avx' for target 'arm64-apple-macosx'
```