### PR TITLE
docs: replace TODO with API reference for Go bindings

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -45,7 +45,56 @@ type AggregateSignature = blst.P1Aggregate
 type AggregatePublicKey = blst.P2Aggregate
 ```
 
-TODO - structures and possibly methods
+## Core Types and Methods
+
+### Basic Types
+- `SecretKey` - Represents a BLS private key (32 bytes)
+- `P1Affine` - Represents a public key in G1 (minimal-pubkey-size mode)
+- `P2Affine` - Represents a signature in G2 (minimal-pubkey-size mode)
+- `P1Aggregate` - For aggregating multiple public keys
+- `P2Aggregate` - For aggregating multiple signatures
+
+### Key Methods
+
+#### SecretKey Methods
+- `KeyGen(ikm []byte) *SecretKey` - Generate a secret key from input key material
+- `Serialize() []byte` - Serialize the secret key to bytes
+- `Deserialize(data []byte) *SecretKey` - Deserialize secret key from bytes
+- `Zeroize()` - Securely zero out the secret key
+
+#### PublicKey (P1Affine) Methods
+- `From(sk *SecretKey) *P1Affine` - Derive public key from secret key
+- `Compress() []byte` - Compress public key to 48 bytes
+- `Uncompress(data []byte) *P1Affine` - Decompress public key from bytes
+- `Serialize() []byte` - Serialize public key to bytes
+- `Deserialize(data []byte) *P1Affine` - Deserialize public key from bytes
+- `Equals(other *P1Affine) bool` - Check if two public keys are equal
+
+#### Signature (P2Affine) Methods
+- `Sign(sk *SecretKey, msg []byte, dst []byte, ...interface{}) *P2Affine` - Sign a message
+- `Verify(sigCheck bool, pk *P1Affine, msgCheck bool, msg []byte, dst []byte, ...interface{}) bool` - Verify a signature
+- `VerifyCompressed(sig []byte, sigCheck bool, pk []byte, msgCheck bool, msg []byte, dst []byte, ...interface{}) bool` - Verify using compressed inputs
+- `Compress() []byte` - Compress signature to 96 bytes
+- `Uncompress(data []byte) *P2Affine` - Decompress signature from bytes
+- `AggregateVerify(sigCheck bool, pks []*P1Affine, msgCheck bool, msgs [][]byte, dst []byte) bool` - Verify multiple signatures
+- `AggregateVerifyCompressed(sig []byte, sigCheck bool, pks [][]byte, msgCheck bool, msgs [][]byte, dst []byte) bool` - Verify using compressed inputs
+- `FastAggregateVerify(sigCheck bool, pks []*P1Affine, msg []byte, dst []byte) bool` - Fast verify for same message
+- `MultipleAggregateVerify(sigs []*P2Affine, sigCheck bool, pks []*P1Affine, msgCheck bool, msgs [][]byte, dst []byte, randFn func(*Scalar), randBits int) bool` - Verify multiple aggregated signatures
+- `BatchUncompress(compressedSigs [][]byte) []*P2Affine` - Efficiently uncompress multiple signatures
+
+#### Aggregate Types
+- `P1Aggregate.Aggregate(pks []*P1Affine, check bool)` - Aggregate multiple public keys
+- `P2Aggregate.Aggregate(sigs []*P2Affine, check bool)` - Aggregate multiple signatures
+- `P2Aggregate.AggregateCompressed(compressedSigs [][]byte, check bool)` - Aggregate compressed signatures
+- `P1Aggregate.ToAffine() *P1Affine` - Convert aggregate to affine form
+- `P2Aggregate.ToAffine() *P2Affine` - Convert aggregate to affine form
+
+#### Utility Functions
+- `HashToG1(msg []byte, dst []byte) *P1` - Hash message to G1 point
+- `HashToG2(msg []byte, dst []byte) *P2` - Hash message to G2 point
+- `P1Generator() *P1` - Get G1 generator point
+- `P2Generator() *P2` - Get G2 generator point
+- `SetMaxProcs(procs int)` - Set maximum number of threads for parallel operations
 
 A complete example for generating a key, signing a message, and verifying the message:
 ```


### PR DESCRIPTION
- Replace "TODO - structures and possibly methods" 
- Add method signatures for SecretKey, P1Affine, P2Affine operations
- Document aggregation and utility functions