### PR TITLE
fix: min-sig infinity uncompress buffer via constant mapping

### DIFF
--- a/bindings/go/blst_minpk_test.go
+++ b/bindings/go/blst_minpk_test.go
@@ -30,7 +30,7 @@ func init() {
 
 func TestInfinityMinPk(t *testing.T) {
     t.Parallel()
-    var infComp [48]byte
+    var infComp [BLST_P1_COMPRESS_BYTES]byte
     infComp[0] |= 0xc0
     new(PublicKeyMinPk).Uncompress(infComp[:])
 }


### PR DESCRIPTION
Problem: In min-sig TestInfinityMinSig, the compressed buffer was 48 bytes, but PublicKeyMinSig = P2Affine (G2) requires 96-byte compressed input. Due to a strict length check in P2Affine.Uncompress, the call returned nil immediately, so the test never exercised infinity handling.

Why it mattered: The test gave a false sense of coverage; it didn’t validate the infinity encoding path for G2 and could mask regressions.

Solution: Updated the generator source test bindings/go/blst_minpk_test.go to use BLST_P1_COMPRESS_BYTES instead of a hardcoded 48. The generator remaps this to BLST_P2_COMPRESS_BYTES for min-sig, yielding the correct 96-byte buffer after regeneration. This keeps tests correct and robust across future code generation.