### PR TITLE
Fix inconsistency in how `__blst_platform_cap` is defined

### DIFF
--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -5,9 +5,9 @@
  */
 
 #if (defined(__GNUC__) || defined(__clang__) || defined(__SUNPRO_C)) && !defined(_WIN32)
-__attribute__((visibility("hidden")))
+__attribute__((visibility("hidden"), common))
 #endif
-int __blst_platform_cap = 0;
+int __blst_platform_cap;
 
 #if defined(__x86_64__) || defined(__x86_64) || (defined(_M_X64) && !defined(_M_ARM64EC))
 


### PR DESCRIPTION
In C it's a BSS symbol, and in assembly it's a common symbol:

```shellsession
$ nm -og libblst.a | grep __blst_platform_cap
libblst.a:assembly.o:0000000000000004 C __blst_platform_cap
libblst.a:server.o:0000000000000000 B __blst_platform_cap
```

This causes problems for some toolchains.

With this change, it becomes:

```shellsession
$ nm -og libblst.a | grep __blst_platform_cap
libblst.a:assembly.o:0000000000000004 C __blst_platform_cap
libblst.a:server.o:0000000000000004 C __blst_platform_cap
```