### PR TITLE
bindings/rust: expose `std` as a Cargo feature

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -26,7 +26,9 @@ links = "blst"
 [features]
 # By default, compile with ADX extension if the host supports it.
 # Binary can be executed on systems similar to the host.
-default = []
+default = ["std"]
+# Use the Rust standard library and enable the thread pool on supported targets.
+std = ["dep:threadpool"]
 # Compile in portable mode, without ISA extensions.
 # Binary can be executed on all systems.
 portable = []
@@ -49,7 +51,7 @@ zeroize = { version = "^1.1", features = ["zeroize_derive"] }
 serde = { version = "1.0.152", optional = true }
 
 [target.'cfg(not(any(target_arch="wasm32", target_os="none", target_os="unknown", target_os="uefi")))'.dependencies]
-threadpool = "^1.8.1"
+threadpool = { version = "^1.8.1", optional = true }
 
 [dev-dependencies]
 rand_core = { version = "0.6", features = ["std"] }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -43,16 +43,16 @@ fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
 
-    let target_no_std = target_os.eq("none")
+    let target_no_std = !cfg!(feature = "std")
+        || target_os.eq("none")
         || (target_os.eq("unknown") && target_arch.eq("wasm32"))
         || target_os.eq("uefi")
         || env::var("BLST_TEST_NO_STD").is_ok();
 
-    if !target_no_std {
-        println!("cargo:rustc-cfg=feature=\"std\"");
-        if target_arch.eq("wasm32") || target_os.eq("unknown") {
-            println!("cargo:rustc-cfg=feature=\"no-threads\"");
-        }
+    // wasm32 and unknown-OS targets can have std but no usable OS threads, so
+    // force the single-threaded path even when std is available.
+    if !target_no_std && (target_arch.eq("wasm32") || target_os.eq("unknown")) {
+        println!("cargo:rustc-cfg=feature=\"no-threads\"");
     }
     println!("cargo:rerun-if-env-changed=BLST_TEST_NO_STD");
 


### PR DESCRIPTION
std is currently inferred purely from the target  triple in build.rs, so a consumer building for a hosted-looking target cannot opt out of std and the threadpool   dependency. This makes `std` a real, default-on Cargo feature gating `threadpool`, and folds it into   build.rs no_std detection so `--no-default-features` (or BLST_TEST_NO_STD) yields a genuine no_std build.  Target-based detection and the wasm32/unknown auto no-threads behaviour are preserved.